### PR TITLE
Remove networks and add Quai Colosseum and Quai Local

### DIFF
--- a/background/constants/assets.ts
+++ b/background/constants/assets.ts
@@ -1,5 +1,5 @@
+import { QUAI_NETWORK } from "./networks"
 import { SmartContractFungibleAsset } from "../assets"
-import { ETHEREUM } from "./networks"
 import { WEBSITE_ORIGIN } from "./website"
 
 /**
@@ -12,7 +12,7 @@ export const DOGGO: SmartContractFungibleAsset = {
   symbol: "DOGGO",
   decimals: 18,
   contractAddress: "0xdce3d2c2186e3E92af121F477dE76cBED2fc979F",
-  homeNetwork: ETHEREUM,
+  homeNetwork: QUAI_NETWORK,
   metadata: {
     tokenLists: [],
     websiteURL: WEBSITE_ORIGIN,

--- a/background/constants/base-assets.ts
+++ b/background/constants/base-assets.ts
@@ -1,4 +1,4 @@
-import { CURRENT_QUAI_CHAIN_ID, NetworkBaseAsset } from "../networks"
+import { NetworkBaseAsset } from "../networks"
 
 const ETH: NetworkBaseAsset = {
   chainID: "1",
@@ -95,8 +95,20 @@ const BNB: NetworkBaseAsset = {
 }
 
 const QUAI: NetworkBaseAsset = {
-  chainID: CURRENT_QUAI_CHAIN_ID,
+  chainID: "9000",
   name: "Quai Network",
+  symbol: "QUAI",
+  decimals: 18,
+  metadata: {
+    coinGeckoID: "",
+    tokenLists: [],
+    websiteURL: "https://qu.ai/",
+  },
+}
+
+const QUAI_LOCAL: NetworkBaseAsset = {
+  chainID: "1337",
+  name: "Quai Network Local",
   symbol: "QUAI",
   decimals: 18,
   metadata: {
@@ -123,6 +135,7 @@ export const BASE_ASSETS_BY_CUSTOM_NAME = {
   GOERLI_ETH,
   ZK_SYNC_ETH,
   QUAI,
+  QUAI_LOCAL,
 }
 
 export const BASE_ASSETS = Object.values(BASE_ASSETS_BY_CUSTOM_NAME)

--- a/background/constants/base-assets.ts
+++ b/background/constants/base-assets.ts
@@ -100,7 +100,7 @@ const QUAI: NetworkBaseAsset = {
   symbol: "QUAI",
   decimals: 18,
   metadata: {
-    coinGeckoID: "usdt",
+    coinGeckoID: "",
     tokenLists: [],
     websiteURL: "https://qu.ai/",
   },

--- a/background/constants/currencies.ts
+++ b/background/constants/currencies.ts
@@ -99,7 +99,17 @@ export const QUAI: NetworkBaseAsset & Required<CoinGeckoAsset> = {
   ...BASE_ASSETS_BY_CUSTOM_NAME.QUAI,
   coinType: coinTypesByAssetSymbol.QUAI,
   metadata: {
-    coinGeckoID: "usdt",
+    coinGeckoID: "",
+    tokenLists: [],
+    websiteURL: "https://qu.ai/",
+  },
+}
+
+export const QUAI_LOCAL: NetworkBaseAsset & Required<CoinGeckoAsset> = {
+  ...BASE_ASSETS_BY_CUSTOM_NAME.QUAI_LOCAL,
+  coinType: coinTypesByAssetSymbol.QUAI,
+  metadata: {
+    coinGeckoID: "",
     tokenLists: [],
     websiteURL: "https://qu.ai/",
   },

--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -107,16 +107,7 @@ export const QUAI_NETWORK: EVMNetwork = {
 }
 
 export const DEFAULT_NETWORKS = [
-  ETHEREUM,
-  POLYGON,
-  OPTIMISM,
-  GOERLI,
-  ARBITRUM_ONE,
-  ROOTSTOCK,
-  AVALANCHE,
-  BINANCE_SMART_CHAIN,
   QUAI_NETWORK,
-  ...wrapIfEnabled(FeatureFlags.SUPPORT_ARBITRUM_NOVA, ARBITRUM_NOVA),
 ]
 
 export function isBuiltInNetwork(network: EVMNetwork): boolean {
@@ -148,17 +139,6 @@ export const CHAINS_WITH_MEMPOOL = new Set(
 )
 
 export const NETWORK_BY_CHAIN_ID = {
-  [ETHEREUM.chainID]: ETHEREUM,
-  [POLYGON.chainID]: POLYGON,
-  [ROOTSTOCK.chainID]: ROOTSTOCK,
-  [ARBITRUM_ONE.chainID]: ARBITRUM_ONE,
-  [AVALANCHE.chainID]: AVALANCHE,
-  [ARBITRUM_NOVA.chainID]: ARBITRUM_NOVA,
-  [OPTIMISM.chainID]: OPTIMISM,
-  [BINANCE_SMART_CHAIN.chainID]: BINANCE_SMART_CHAIN,
-  [GOERLI.chainID]: GOERLI,
-  [FORK.chainID]: FORK,
-  [ZK_SYNC.chainID]: ZK_SYNC,
   [QUAI_NETWORK.chainID]: QUAI_NETWORK,
 }
 
@@ -166,7 +146,7 @@ export const TEST_NETWORK_BY_CHAIN_ID = new Set(
   [GOERLI].map((network) => network.chainID)
 )
 
-export const NETWORK_FOR_LEDGER_SIGNING = [ETHEREUM, POLYGON]
+export const NETWORK_FOR_LEDGER_SIGNING = []
 
 // Networks that are not added to this struct will
 // not have an in-wallet Swap page
@@ -296,7 +276,7 @@ export const NETWORK_TO_CHAIN_ID = {
   Local: 1337
 }
 
-export const DEFAULT_QUAI_TESNTET = {
+export const DEFAULT_QUAI_TESTNET = {
   name: "Colosseum",
   chainCode: 994,
   chainID: 9000,
@@ -433,7 +413,7 @@ export const DEFAULT_QUAI_LOCAL = {
       shard: "cyprus-1",
       rpc: "http://localhost:8610",
       blockExplorerUrl: "https://dev.cyprus1.quaiscan.io",
-      multicall: "0x15b6351eDEcd7142ac4c6fE54948b603D4566862"
+      multicall: "0x1aF3f0d55e6f399708a058333E81604F56f22835"//"0x15b6351eDEcd7142ac4c6fE54948b603D4566862"
     },
     {
       name: "Cyprus Two",
@@ -495,7 +475,7 @@ export const DEFAULT_QUAI_LOCAL = {
 } as Network
 
 export const DEFAULT_QUAI_NETWORKS = [
-  DEFAULT_QUAI_TESNTET,
+  DEFAULT_QUAI_TESTNET,
   DEFAULT_QUAI_DEVNET,
   DEFAULT_QUAI_LOCAL
 ]
@@ -626,6 +606,7 @@ export function setProviderForShard(providers: SerialFallbackProvider): SerialFa
   if (shard === undefined || shard == "") {
     return providers
   }
+  
   for (let provider of providers.providerCreators) {
     if (provider.shard !== undefined && provider.shard == shard) {
       let quaisProvider = provider.creator()

--- a/background/lib/erc20.ts
+++ b/background/lib/erc20.ts
@@ -8,7 +8,7 @@ import {
   TransactionDescription,
 } from "ethers/lib/utils"
 import { SmartContractAmount, SmartContractFungibleAsset } from "../assets"
-import { CURRENT_QUAI_CHAIN_ID, EVMLog, SmartContract } from "../networks"
+import { EVMLog, SmartContract } from "../networks"
 import { HexString } from "../types"
 import { AddressOnNetwork } from "../accounts"
 import {
@@ -198,8 +198,8 @@ export const getTokenBalances = async (
   let multicallAddress =
     CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES[network.chainID] ||
     MULTICALL_CONTRACT_ADDRESS
-  if (network.chainID == CURRENT_QUAI_CHAIN_ID) {
-    multicallAddress = ShardToMulticall(globalThis.main.SelectedShard)
+  if (network.isQuai) {
+    multicallAddress = ShardToMulticall(globalThis.main.SelectedShard, network)
   }
 
   const contract = new quais.Contract(

--- a/background/lib/poap.ts
+++ b/background/lib/poap.ts
@@ -1,6 +1,6 @@
 import { fetchJson } from "@ethersproject/web"
 import logger from "./logger"
-import { ETHEREUM } from "../constants"
+import { ETHEREUM, QUAI_NETWORK } from "../constants"
 import { NFT, NFTCollection, NFTsWithPagesResponse } from "../nfts"
 
 export const POAP_CONTRACT = "0x22C1f6050E56d2876009903609a2cC3fEf83B415" // POAP contract address https://etherscan.io/address/0x22C1f6050E56d2876009903609a2cC3fEf83B415
@@ -58,7 +58,7 @@ function poapNFTModelToNFT(original: PoapNFTModel, owner: string): NFT {
     collectionID: POAP_COLLECTION_ID,
     contract: POAP_CONTRACT, // contract address doesn't make sense for POAPs
     owner,
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     supply,
     isBadge: true,
     rarity: {}, // no rarity rankings for POAPs
@@ -108,7 +108,7 @@ export async function getPoapCollections(
     nftCount: undefined, // TODO: we don't know at this point how many POAPs this address has
     owner: address,
     hasBadges: true,
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     floorPrice: undefined, // POAPs don't have floor prices
     thumbnailURL: "images/poap_logo.svg",
   }

--- a/background/lib/priceOracle.ts
+++ b/background/lib/priceOracle.ts
@@ -30,7 +30,7 @@ import {
 } from "./multicall"
 import { toFixedPoint } from "./fixed-point"
 import SerialFallbackProvider from "../services/chain/serial-fallback-provider"
-import { CURRENT_QUAI_CHAIN_ID, EVMNetwork } from "../networks"
+import { EVMNetwork } from "../networks"
 
 // Oracle Documentation and Address references can be found
 // at https://docs.1inch.io/docs/spot-price-aggregator/introduction/
@@ -154,8 +154,8 @@ const getRatesForTokens = async (
   }[]
 > => {
   let multicallAddress = MULTICALL_CONTRACT_ADDRESS
-  if(network.chainID === CURRENT_QUAI_CHAIN_ID) {
-    multicallAddress = ShardToMulticall(globalThis.main.SelectedShard)
+  if(network.isQuai) {
+    multicallAddress = ShardToMulticall(globalThis.main.SelectedShard, network)
   }
   const multicall = new ethers.Contract(
     multicallAddress,

--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -2,7 +2,7 @@ import { BigNumber, ethers, utils } from "ethers"
 import { normalizeHexAddress, toChecksumAddress } from "@pelagus/hd-keyring"
 import { NormalizedEVMAddress, UNIXTime } from "../../types"
 import { EVMNetwork } from "../../networks"
-import { ETHEREUM, GOERLI } from "../../constants"
+import { ETHEREUM, GOERLI, QUAI_NETWORK } from "../../constants"
 import { AddressOnNetwork } from "../../accounts"
 
 export function isValidChecksumAddress(
@@ -162,7 +162,7 @@ export function getEthereumNetwork(): EVMNetwork {
   }
 
   // Default to mainnet
-  return ETHEREUM
+  return QUAI_NETWORK
 }
 
 export function isProbablyEVMAddress(str: string): boolean {

--- a/background/lib/utils/index.ts
+++ b/background/lib/utils/index.ts
@@ -2,7 +2,7 @@ import { BigNumber, ethers, utils } from "ethers"
 import { normalizeHexAddress, toChecksumAddress } from "@pelagus/hd-keyring"
 import { NormalizedEVMAddress, UNIXTime } from "../../types"
 import { EVMNetwork } from "../../networks"
-import { ETHEREUM, GOERLI, QUAI_NETWORK } from "../../constants"
+import { ETHEREUM, GOERLI, QUAI_NETWORK, QUAI_NETWORK_LOCAL } from "../../constants"
 import { AddressOnNetwork } from "../../accounts"
 
 export function isValidChecksumAddress(
@@ -157,8 +157,8 @@ export function decodeJSON(input: string): unknown {
 export function getEthereumNetwork(): EVMNetwork {
   const ethereumNetwork = process.env.ETHEREUM_NETWORK?.toUpperCase()
 
-  if (ethereumNetwork === "GOERLI") {
-    return GOERLI
+  if (ethereumNetwork === "LOCAL") {
+    return QUAI_NETWORK_LOCAL
   }
 
   // Default to mainnet

--- a/background/networks.ts
+++ b/background/networks.ts
@@ -9,8 +9,7 @@ import type {
   EnrichedEVMTransactionSignatureRequest,
   PartialTransactionRequestWithFrom,
 } from "./services/enrichment"
-
-export const CURRENT_QUAI_CHAIN_ID = "1337"
+import { ChainData } from "./constants"
 
 /**
  * Each supported network family is generally incompatible with others from a
@@ -68,6 +67,8 @@ export type EVMNetwork = Network & {
    * Provided for custom networks
    */
   blockExplorerURL?: string
+  chains?: ChainData[]
+  isQuai?: boolean
 }
 
 /**

--- a/background/redux-slices/dapp.ts
+++ b/background/redux-slices/dapp.ts
@@ -11,6 +11,7 @@ import {
   GOERLI,
   OPTIMISM,
   POLYGON,
+  QUAI_NETWORK,
   ROOTSTOCK,
 } from "../constants"
 
@@ -128,14 +129,15 @@ const dappSlice = createSlice({
 
           // Support all networks regardless of which one initiated grant request
           const permissions = [
-            ETHEREUM,
+            /*ETHEREUM,
             ROOTSTOCK,
             POLYGON,
             OPTIMISM,
             AVALANCHE,
             BINANCE_SMART_CHAIN,
             GOERLI,
-            ARBITRUM_NOVA,
+            ARBITRUM_NOVA,*/
+            QUAI_NETWORK,
           ].map((network) => ({
             ...permission,
             chainID: network.chainID,

--- a/background/redux-slices/earn.ts
+++ b/background/redux-slices/earn.ts
@@ -20,7 +20,7 @@ import {
 } from "./utils/contract-utils"
 import { AssetsState } from "./assets"
 import { enrichAssetAmountWithMainCurrencyValues } from "./utils/asset-utils"
-import { ETHEREUM } from "../constants"
+import { ETHEREUM, QUAI_NETWORK } from "../constants"
 import { EVMNetwork } from "../networks"
 import YEARN_VAULT_ABI from "../lib/yearnVault"
 import { getPoolAPR, getTokenPrice, tokenIcons } from "./earn-utils"
@@ -92,7 +92,7 @@ export type Events = {
 
 export const initialVaults: AvailableVault[] = [
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.AAVE,
     vaultAddress: "0xE1B460d1056FfC314E43eF8A95Bd76Aef2a5E903",
     yearnVault: "0xd9788f3931Ede4D5018184E198699dC6d66C1915",
@@ -112,7 +112,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.UNI,
     vaultAddress: "0x94bE1e2459e3E6b1750b9B3C1B04Ba97aaDaCdA7",
     yearnVault: "0xFBEB78a723b8087fD2ea7Ef1afEc93d35E8Bed42",
@@ -132,7 +132,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.crvCVXETH,
     vaultAddress: "0x18a28995816Ee6d26cEeA3c39454C5FFBFCB7C71",
     yearnVault: "0x1635b506a88fBF428465Ad65d00e8d6B6E5846C3",
@@ -152,7 +152,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons["YFIETH-f"],
     vaultAddress: "0x4852190BB1f092310ef616f1FC7B2E17998261bb",
     yearnVault: "0x790a60024bC3aea28385b60480f15a0771f26D09",
@@ -172,7 +172,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.SNX,
     vaultAddress: "0x1388B70e1b70E1cBa49A5435090625bd6ce2374A",
     yearnVault: "0xF29AE508698bDeF169B89834F76704C3B205aedf",
@@ -192,7 +192,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.SUSHI,
     vaultAddress: "0x7B0902F5286D9E3333588F3B550EfC3b9Eb4a9dD",
     yearnVault: "0x6d765CbE5bC922694afE112C140b8878b9FB0390",
@@ -212,7 +212,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.LOOKS,
     vaultAddress: "0x74B7382fA81Cee6C18f6D6694AdCA6861605a068",
     yearnVault: "0x5faF6a2D186448Dfa667c51CB3D695c7A6E52d8E",
@@ -232,7 +232,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.KEEP,
     vaultAddress: "0x77B59394639d1591632C6B6BA5E2b8afc1151bD0",
     yearnVault: "0xb09F2a67a731466182518fae980feAe96479d80b",
@@ -252,7 +252,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
     icons: tokenIcons.crvTETH,
     vaultAddress: "0xAaa2096f5832e5d7D7e0d30eE2181929878207f4",
     yearnVault: "0xF6B9DFE6bc42ed2eaB44D6B829017f7B78B29f88",
@@ -272,7 +272,7 @@ export const initialVaults: AvailableVault[] = [
     pendingRewards: 0n,
   },
   {
-    network: ETHEREUM,
+  network: QUAI_NETWORK,
     icons: tokenIcons.DOGGOETH,
     vaultAddress: "0x041BE32B10eC4740387a42Bd82703798A9303753",
     yearnVault: "0x9A39f31DD5EDF5919A5C0c2433cE053fAD2E0336",

--- a/background/redux-slices/networks.ts
+++ b/background/redux-slices/networks.ts
@@ -1,6 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit"
 import type { RootState } from "."
-import { ETHEREUM } from "../constants"
+import { ETHEREUM, QUAI_CONTEXTS, QUAI_NETWORK } from "../constants"
 import { EIP1559Block, AnyEVMBlock, EVMNetwork } from "../networks"
 import { removeChainBalances } from "./accounts"
 import { selectCurrentNetwork } from "./selectors/uiSelectors"
@@ -88,7 +88,7 @@ export const removeCustomChain = createBackgroundAsyncThunk(
     const currentNetwork = selectCurrentNetwork(store)
 
     if (currentNetwork.chainID === chainID) {
-      await dispatch(setSelectedNetwork(ETHEREUM))
+      await dispatch(setSelectedNetwork(QUAI_NETWORK))
     }
     await dispatch(removeChainBalances(chainID))
 

--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -1,7 +1,7 @@
 import { createSlice, createSelector } from "@reduxjs/toolkit"
 import Emittery from "emittery"
 import { AddressOnNetwork } from "../accounts"
-import { ETHEREUM } from "../constants"
+import { ETHEREUM, QUAI_NETWORK } from "../constants"
 import { AnalyticsEvent, OneTimeAnalyticsEvent } from "../lib/posthog"
 import { EVMNetwork } from "../networks"
 import { AnalyticsPreferences } from "../services/preferences/types"
@@ -61,7 +61,7 @@ export const initialState: UIState = {
   showingActivityDetailID: null,
   selectedAccount: {
     address: "",
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
   },
   initializationLoadingTimeExpired: false,
   settings: defaultSettings,
@@ -284,6 +284,9 @@ export const userActivityEncountered = createBackgroundAsyncThunk(
 export const setSelectedNetwork = createBackgroundAsyncThunk(
   "ui/setSelectedNetwork",
   async (network: EVMNetwork, { getState, dispatch }) => {
+    if (network.name == "Ethereum") { // Ethereum is disabled
+      return
+    }
     const state = getState() as { ui: UIState; account: AccountState }
     const { ui, account } = state
     const currentlySelectedChainID = ui.selectedAccount.network.chainID

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -37,6 +37,7 @@ import {
   SECOND,
   setProviderForShard,
   getShardFromAddress,
+  QUAI_NETWORK,
 } from "../../constants"
 import { FeatureFlags, isEnabled } from "../../features"
 import PreferenceService from "../preferences"
@@ -390,6 +391,9 @@ export default class ChainService extends BaseService<Events> {
   providerForNetwork(network: EVMNetwork): SerialFallbackProvider | undefined {
     if (this.providers.evm[network.chainID] === undefined) {
       this.initializeNetworks().then(() => {
+        if (this.providers.evm[network.chainID] === undefined) {
+          console.error("Provider is undefined for network " + network.name)
+        } 
         setProviderForShard(this.providers.evm[network.chainID])
       })
     } else {
@@ -866,7 +870,7 @@ export default class ChainService extends BaseService<Events> {
     const chainIDs = await this.db.getChainIDsToTrack()
     if (chainIDs.size === 0) {
       // Default to tracking Ethereum so ENS resolution works during onboarding
-      return [ETHEREUM]
+      return [QUAI_NETWORK]
     }
 
     const networks = await Promise.all(

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -16,9 +16,12 @@ import {
   ShardFromRpcUrl,
   setProviderForShard,
   ShardToMulticall,
+  CHAIN_ID_TO_NETWORK,
+  NETWORK_TO_CHAIN_ID,
+  NETWORK_BY_CHAIN_ID,
 } from "../../constants"
 import logger from "../../lib/logger"
-import { AnyEVMTransaction, CURRENT_QUAI_CHAIN_ID } from "../../networks"
+import { AnyEVMTransaction } from "../../networks"
 import { AddressOnNetwork } from "../../accounts"
 import { transactionFromEthersTransaction } from "./utils"
 import {
@@ -145,7 +148,6 @@ export default class SerialFallbackProvider extends QuaisJsonRpcProvider {
     type: "alchemy" | "generic" | "Quai"
     shard?: string
     rpcUrl?: string
-    multiCallAddress?: string
     creator: () => WebSocketProvider | JsonRpcProvider | QuaisJsonRpcProvider | QuaisWebSocketProvider
   }>
 
@@ -236,7 +238,6 @@ export default class SerialFallbackProvider extends QuaisJsonRpcProvider {
       type: "alchemy" | "generic" | "Quai"
       shard?: string
       rpcUrl?: string
-      multiCallAddress?: string
       creator: () => WebSocketProvider | JsonRpcProvider | QuaisJsonRpcProvider | QuaisWebSocketProvider
     }>
   ) {
@@ -960,7 +961,7 @@ export function makeSerialFallbackProvider(
       ]
     : []
 
-  const genericProviders = chainID === CURRENT_QUAI_CHAIN_ID ? rpcUrls.map((rpcUrl) => ({
+  const genericProviders = NETWORK_BY_CHAIN_ID[chainID].isQuai ? rpcUrls.map((rpcUrl) => ({
     type: "Quai" as const,
     creator: () => {
       const url = new URL(rpcUrl)
@@ -972,7 +973,6 @@ export function makeSerialFallbackProvider(
     },
     shard: ShardFromRpcUrl(rpcUrl),
     rpcUrl: rpcUrl,
-    multicall: ShardToMulticall(ShardFromRpcUrl(rpcUrl))
   })) :
   rpcUrls.map((rpcUrl) => ({
     type: "generic" as const,

--- a/background/services/doggo/index.ts
+++ b/background/services/doggo/index.ts
@@ -4,7 +4,7 @@ import { Eligible } from "./types"
 import BaseService from "../base"
 import { getFileHashProspect, getClaimFromFileHash } from "./utils"
 import ChainService from "../chain"
-import { DOGGO, ETHEREUM } from "../../constants"
+import { DOGGO, ETHEREUM, QUAI_NETWORK } from "../../constants"
 import { sameNetwork } from "../../networks"
 import { ClaimWithFriends } from "./contracts"
 import IndexingService from "../indexing"
@@ -53,7 +53,7 @@ export default class DoggoService extends BaseService<Events> {
 
     const huntingGrounds = initialVaults
 
-    const ethereumProvider = this.chainService.providerForNetwork(ETHEREUM)
+    const ethereumProvider = this.chainService.providerForNetwork(QUAI_NETWORK)
     if (ethereumProvider === undefined) {
       logger.error(
         "No Ethereum provider available, not setting up DOGGO monitoring..."
@@ -73,7 +73,7 @@ export default class DoggoService extends BaseService<Events> {
       this.indexingService.addAssetToTrack({
         contractAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
         decimals: 18,
-        homeNetwork: ETHEREUM,
+        homeNetwork: QUAI_NETWORK,
         name: "Wrapped Ether",
         symbol: "WETH",
       })

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -1,6 +1,6 @@
 import logger from "../../lib/logger"
 import { HexString } from "../../types"
-import { CURRENT_QUAI_CHAIN_ID, EVMNetwork, sameNetwork } from "../../networks"
+import { EVMNetwork, sameNetwork } from "../../networks"
 import { AccountBalance, AddressOnNetwork } from "../../accounts"
 import {
   AnyAsset,
@@ -952,7 +952,7 @@ export default class IndexingService extends BaseService<Events> {
         const { network } = addressOnNetwork
         
         let prevShard = globalThis.main.SelectedShard
-        if (network.chainID === CURRENT_QUAI_CHAIN_ID) {
+        if (network.isQuai) {
           let shard = getShardFromAddress(addressOnNetwork.address)
           globalThis.main.SetShard(shard)
         }

--- a/background/services/internal-ethereum-provider/db.ts
+++ b/background/services/internal-ethereum-provider/db.ts
@@ -1,5 +1,5 @@
 import Dexie from "dexie"
-import { ETHEREUM } from "../../constants"
+import { ETHEREUM, QUAI_NETWORK } from "../../constants"
 import { EVMNetwork } from "../../networks"
 import { TALLY_INTERNAL_ORIGIN } from "./constants"
 
@@ -42,7 +42,7 @@ export class InternalEthereumProviderDatabase extends Dexie {
     this.on("populate", (tx) => {
       return tx.db
         .table("currentNetwork")
-        .add({ origin: TALLY_INTERNAL_ORIGIN, network: ETHEREUM })
+        .add({ origin: TALLY_INTERNAL_ORIGIN, network: QUAI_NETWORK })
     })
   }
 

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -34,7 +34,7 @@ import {
 } from "../../utils/signing"
 import { getOrCreateDB, InternalEthereumProviderDatabase } from "./db"
 import { TALLY_INTERNAL_ORIGIN } from "./constants"
-import { ROOTSTOCK } from "../../constants"
+import { QUAI_NETWORK, ROOTSTOCK } from "../../constants"
 import {
   EnrichedEVMTransactionRequest,
   TransactionAnnotation,
@@ -384,14 +384,15 @@ export default class InternalEthereumProviderService extends BaseService<Events>
   async getCurrentOrDefaultNetworkForOrigin(
     origin: string
   ): Promise<EVMNetwork> {
-    const currentNetwork = await this.db.getCurrentNetworkForOrigin(origin)
+    /*const currentNetwork = await this.db.getCurrentNetworkForOrigin(origin)
     if (!currentNetwork) {
       // If this is a new dapp or the dapp has not implemented wallet_switchEthereumChain
       // use the default network.
       const defaultNetwork = await this.getCurrentInternalNetwork()
       return defaultNetwork
     }
-    return currentNetwork
+    return currentNetwork*/
+    return QUAI_NETWORK
   }
 
   async removePrefererencesForChain(chainId: string): Promise<void> {

--- a/background/services/name/resolvers/ens.ts
+++ b/background/services/name/resolvers/ens.ts
@@ -8,6 +8,7 @@ import {
   GOERLI,
   OPTIMISM,
   POLYGON,
+  QUAI_NETWORK,
 } from "../../../constants"
 import { sameNetwork } from "../../../networks"
 import { NameResolver } from "../name-resolver"
@@ -76,7 +77,7 @@ export default function ensResolverFor(
             }
 
       // Hard-coded to ETHEREUM to support ENS names on ETH L2's.
-      const provider = chainService.providerForNetwork(ETHEREUM)
+      const provider = chainService.providerForNetwork(QUAI_NETWORK)
 
       if (name === undefined || provider === undefined) {
         return undefined
@@ -101,7 +102,7 @@ export default function ensResolverFor(
     }: AddressOnNetwork): Promise<NameOnNetwork | undefined> {
       const name = await chainService
         // Hard-coded to ETHEREUM to support ENS names on ETH L2's.
-        .providerForNetwork(ETHEREUM)
+        .providerForNetwork(QUAI_NETWORK)
         ?.lookupAddress(address)
 
       if (name === undefined || name === null) {

--- a/background/services/name/resolvers/ens.ts
+++ b/background/services/name/resolvers/ens.ts
@@ -76,7 +76,7 @@ export default function ensResolverFor(
               name: undefined,
             }
 
-      // Hard-coded to ETHEREUM to support ENS names on ETH L2's.
+      // Hard-coded to QUAI_NETWORK to support QNS names.
       const provider = chainService.providerForNetwork(QUAI_NETWORK)
 
       if (name === undefined || provider === undefined) {

--- a/background/services/preferences/defaults.ts
+++ b/background/services/preferences/defaults.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM, USD } from "../../constants"
+import { ETHEREUM, QUAI_NETWORK, USD } from "../../constants"
 import { storageGatewayURL } from "../../lib/storage-gateway"
 import { Preferences } from "./types"
 
@@ -26,7 +26,7 @@ const defaultPreferences: Preferences = {
   defaultWallet: false,
   selectedAccount: {
     address: "",
-    network: ETHEREUM,
+    network: QUAI_NETWORK,
   },
   accountSignersSettings: [],
   analytics: {

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -121,7 +121,7 @@ export default function Wallet(): ReactElement {
         <div className="section">
           <WalletAccountBalanceControl
             balance={totalMainCurrencyValue}
-            mainAssetBalance={assetAmounts[0].decimalAmount.toFixed(3).toString() ?? "0"}
+            mainAssetBalance={assetAmounts[0] != undefined ? (assetAmounts[0].decimalAmount.toFixed(3).toString() ?? "0") : "0"}
             initializationLoadingTimeExpired={initializationLoadingTimeExpired}
           />
         </div>

--- a/ui/utils/constants.ts
+++ b/ui/utils/constants.ts
@@ -7,11 +7,12 @@ import {
   GOERLI,
   OPTIMISM,
   POLYGON,
+  QUAI_NETWORK,
+  QUAI_NETWORK_LOCAL,
   ROOTSTOCK,
 } from "@tallyho/tally-background/constants"
 import { NetworkFeeTypeChosen } from "@tallyho/tally-background/redux-slices/transaction-construction"
 import { i18n } from "../_locales/i18n"
-import { CURRENT_QUAI_CHAIN_ID } from "@tallyho/tally-background/networks"
 
 export const doggoTokenDecimalDigits = 18
 
@@ -34,7 +35,11 @@ export const blockExplorer = {
     title: "Arbiscan",
     url: "https://nova.arbiscan.io/",
   },
-  [CURRENT_QUAI_CHAIN_ID]: {
+  [QUAI_NETWORK.chainID]: {
+    title: "Quai Blockscout",
+    url: "https://cyprus1.colosseum.quaiscan.io", // TODO: update this per shard
+  },
+  [QUAI_NETWORK_LOCAL.chainID]: {
     title: "Quai Blockscout",
     url: "https://cyprus1.colosseum.quaiscan.io", // TODO: update this per shard
   }


### PR DESCRIPTION
This PR removes other networks and adds preference for Quai Colosseum in defaults. Also adds Quai Local network.
Note: Local will have to be run in a browser with out CORS protection; for example: open -n -a /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --user-data-dir="/tmp/chrome_dev_test" --disable-web-security

Blockscout will still not work outside of cyprus-1. The explorer interface needs refactoring to support shard-specific explorer URLs.