### PR TITLE
Feature: Add send advanced tab, private key export and provider caching

### DIFF
--- a/background/lib/erc20.ts
+++ b/background/lib/erc20.ts
@@ -20,6 +20,7 @@ import {
 import logger from "./logger"
 import SerialFallbackProvider from "../services/chain/serial-fallback-provider"
 import { ShardToMulticall, getShardFromAddress } from "../constants"
+import { get } from "lodash"
 
 export const ERC20_FUNCTIONS = {
   allowance: FunctionFragment.from(
@@ -202,7 +203,7 @@ export const getTokenBalances = async (
     CHAIN_SPECIFIC_MULTICALL_CONTRACT_ADDRESSES[network.chainID] ||
     MULTICALL_CONTRACT_ADDRESS
   if (network.isQuai) {
-    multicallAddress = ShardToMulticall(globalThis.main.SelectedShard, network)
+    multicallAddress = ShardToMulticall(getShardFromAddress(address), network)
   }
 
   const contract = new quais.Contract(

--- a/background/main.ts
+++ b/background/main.ts
@@ -965,9 +965,9 @@ export default class Main extends BaseService<never> {
           const signedTransactionResult =
             await this.signingService.signTransaction(request, accountSigner)
           await this.store.dispatch(transactionSigned(signedTransactionResult))
-          transactionConstructionSliceEmitter.emit("signedTransactionResult", 
+          setTimeout(() => transactionConstructionSliceEmitter.emit("signedTransactionResult", 
             signedTransactionResult
-          )
+          ), 1000) // could check broadcastOnSign here and broadcast if false but this is a hacky solution (could result in tx broadcasted twice)
           this.analyticsService.sendAnalyticsEvent(
             AnalyticsEvent.TRANSACTION_SIGNED,
             {

--- a/background/main.ts
+++ b/background/main.ts
@@ -189,6 +189,8 @@ import {
 import { isBuiltInNetworkBaseAsset } from "./redux-slices/utils/asset-utils"
 import { getPricePoint, getTokenPrices } from "./lib/prices"
 import localStorageShim from "./utils/local-storage-shim"
+import { JsonRpcProvider, WebSocketProvider } from "@ethersproject/providers"
+import { JsonRpcProvider as QuaisJsonRpcProvider, WebSocketProvider as QuaisWebSocketProvider } from "@quais/providers"
 
 // This sanitizer runs on store and action data before serializing for remote
 // redux devtools. The goal is to end up with an object that is directly
@@ -297,6 +299,8 @@ export default class Main extends BaseService<never> {
   store: ReduxStoreType
 
   public SelectedShard: string
+
+  public UrlToProvider: Map<string, JsonRpcProvider | WebSocketProvider | QuaisJsonRpcProvider | QuaisWebSocketProvider>
 
   balanceChecker: NodeJS.Timer
 
@@ -527,6 +531,7 @@ export default class Main extends BaseService<never> {
     })
 
     this.initializeRedux()
+    this.UrlToProvider = new Map()
     globalThis.main = this
   }
 
@@ -1770,6 +1775,10 @@ export default class Main extends BaseService<never> {
 
   async unlockKeyrings(password: string): Promise<boolean> {
     return this.keyringService.unlock(password)
+  }
+
+  async exportPrivKey(address: string): Promise<string> {
+    return this.keyringService.exportPrivKey(address)
   }
 
   async getActivityDetails(txHash: string): Promise<ActivityDetail[]> {

--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -39,6 +39,7 @@ export type Events = {
   generateNewKeyring: string | undefined
   deriveAddress: DeriveAddressData
   importKeyring: ImportKeyring
+  exportPrivKey: string
 }
 
 export const emitter = new Emittery<Events>()
@@ -169,5 +170,12 @@ export const createPassword = createBackgroundAsyncThunk(
   "keyrings/createPassword",
   async (password: string) => {
     await emitter.emit("createPassword", password)
+  }
+)
+
+export const exportPrivKey = createBackgroundAsyncThunk(
+  "keyrings/exportPrivKey",
+  async (address: string) => {
+    return { key: await main.exportPrivKey(address) }
   }
 )

--- a/background/redux-slices/utils/contract-utils.ts
+++ b/background/redux-slices/utils/contract-utils.ts
@@ -2,6 +2,7 @@ import TallyWindowProvider from "@tallyho/window-provider"
 import { Contract, ethers, ContractInterface } from "ethers"
 import Emittery from "emittery"
 import TallyWeb3Provider from "../../tally-provider"
+import { SECOND } from "../../constants"
 
 type InternalProviderPortEvents = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,8 +54,16 @@ export const getSignerAddress = async (): Promise<string> => {
   return signerAddress
 }
 
+var latestBlockNumber = 0
+var latestAsk = 0
 export const getCurrentTimestamp = async (): Promise<number> => {
-  const provider = getProvider()
-  const { timestamp } = await provider.getBlock(provider.getBlockNumber())
-  return timestamp
+  if(latestAsk + 10 * SECOND < Date.now()) {
+    const provider = getProvider()
+    const { timestamp } = await provider.getBlock(provider.getBlockNumber())
+    latestBlockNumber = timestamp
+    latestAsk = Date.now()
+    return timestamp
+  } else {
+    return latestBlockNumber
+  }
 }

--- a/background/services/chain/asset-data-helper.ts
+++ b/background/services/chain/asset-data-helper.ts
@@ -68,9 +68,12 @@ export default class AssetDataHelper {
     addressOnNetwork: AddressOnNetwork,
     smartContractAddresses?: HexString[]
   ): Promise<SmartContractAmount[]> {
+    let prevShard = globalThis.main.GetShard()
+    globalThis.main.SetShard(getShardFromAddress(addressOnNetwork.address))
     const provider = this.providerTracker.providerForNetwork(
       addressOnNetwork.network
     )
+    globalThis.main.SetShard(prevShard)
     if (typeof provider === "undefined") {
       return []
     }

--- a/background/services/chain/index.ts
+++ b/background/services/chain/index.ts
@@ -1,9 +1,9 @@
 import {
   TransactionReceipt,
   TransactionResponse,
-} from "@ethersproject/providers"
-import { BigNumber, ethers, utils } from "ethers"
-import { Logger, UnsignedTransaction } from "ethers/lib/utils"
+} from "@quais/providers"
+import { BigNumber, quais, utils } from "quais"
+import { Logger, UnsignedTransaction } from "quais/lib/utils"
 import logger from "../../lib/logger"
 import getBlockPrices from "../../lib/gas"
 import { HexString, NormalizedEVMAddress, UNIXTime } from "../../types"
@@ -97,9 +97,9 @@ const NETWORK_POLLING_TIMEOUT = MINUTE * 2.05
 // mempool) reasons.
 const TRANSACTION_CHECK_LIFETIME_MS = 10 * HOUR
 
-const GAS_POLLS_PER_PERIOD = 4 // 4 times per minute
+const GAS_POLLS_PER_PERIOD = 1 // 1 time per 5 minutes
 
-const GAS_POLLING_PERIOD = 1 // 1 minute
+const GAS_POLLING_PERIOD = 5 // 5 minutes
 
 // Maximum number of transactions with priority.
 // Transactions that will be retrieved before others for one account.
@@ -254,7 +254,7 @@ export default class ChainService extends BaseService<Events> {
     super({
       queuedTransactions: {
         schedule: {
-          delayInMinutes: 0.5,
+          delayInMinutes: 1,
           periodInMinutes: 1,
         },
         handler: () => {
@@ -633,7 +633,7 @@ export default class ChainService extends BaseService<Events> {
       maxFeePerGas: maxFeePerGas ?? 0n,
       maxPriorityFeePerGas: maxPriorityFeePerGas ?? 0n,
       input: input ?? null,
-      type: 2 as const,
+      type: network.isQuai ? 0 as const : 2 as const,
       network,
       chainID: network.chainID,
       nonce,
@@ -1174,7 +1174,7 @@ export default class ChainService extends BaseService<Events> {
 
     const provider = await this.providerForNetworkOrThrow(network)
 
-    const GasOracle = new ethers.Contract(
+    const GasOracle = new quais.Contract(
       OPTIMISM_GAS_ORACLE_ADDRESS,
       OPTIMISM_GAS_ORACLE_ABI,
       provider

--- a/background/services/chain/serial-fallback-provider.ts
+++ b/background/services/chain/serial-fallback-provider.ts
@@ -361,6 +361,7 @@ export default class SerialFallbackProvider extends QuaisJsonRpcProvider {
         )
       ) {
         if (this.shouldSendMessageOnNextProvider(messageId)) {
+          console.trace()
           // If there is another provider to try - try to send the message on that provider
           if (this.currentProviderIndex + 1 < this.providerCreators.length) {
             return await this.attemptToSendMessageOnNewProvider(messageId)

--- a/background/services/chain/utils/index.ts
+++ b/background/services/chain/utils/index.ts
@@ -7,7 +7,7 @@ import {
 import {
   Transaction as EthersTransaction,
   UnsignedTransaction,
-} from "@ethersproject/transactions"
+} from "@quais/transactions"
 
 import {
   AnyEVMTransaction,

--- a/background/services/enrichment/transactions.ts
+++ b/background/services/enrichment/transactions.ts
@@ -28,7 +28,7 @@ import {
   getERC20LogsForAddresses,
 } from "./utils"
 import { enrichAddressOnNetwork } from "./addresses"
-import { OPTIMISM } from "../../constants"
+import { OPTIMISM, SECOND } from "../../constants"
 import { parseLogsForWrappedDepositsAndWithdrawals } from "../../lib/wrappedAsset"
 import {
   ERC20TransferLog,
@@ -183,6 +183,8 @@ export async function annotationsFromLogs(
  * Resolve an annotation for a partial transaction request, or a pending
  * or mined transaction.
  */
+var latestWorkedAsk = 0
+var numAsks = 0
 export default async function resolveTransactionAnnotation(
   chainService: ChainService,
   indexingService: IndexingService,
@@ -198,6 +200,7 @@ export default async function resolveTransactionAnnotation(
       }),
   desiredDecimals: number
 ): Promise<TransactionAnnotation> {
+  
   const assets = await indexingService.getCachedAssets(network)
 
   // By default, annotate all requests as contract interactions, unless they
@@ -215,6 +218,17 @@ export default async function resolveTransactionAnnotation(
               asset.symbol === transaction.network.baseAsset.symbol
           )?.metadata?.logoURL,
         }
+
+  if(numAsks > 10 && latestWorkedAsk + 5 * SECOND > Date.now()) {
+    // Requesting too often
+    console.log("Requesting tx annotations too often, skipping")
+    return txAnnotation
+  } else if (numAsks > 10 && latestWorkedAsk + 5 * SECOND < Date.now()) {
+    // Reset
+    numAsks = 0
+  }
+  numAsks++
+  latestWorkedAsk = Date.now()
 
   let block: AnyEVMBlock | undefined
 

--- a/background/services/indexing/index.ts
+++ b/background/services/indexing/index.ts
@@ -55,7 +55,7 @@ import {
 const FAST_TOKEN_REFRESH_BLOCK_RANGE = 10
 // The number of ms to coalesce tokens whose balances are known to have changed
 // before balance-checking them.
-const ACCELERATED_TOKEN_REFRESH_TIMEOUT = 300
+const ACCELERATED_TOKEN_REFRESH_TIMEOUT = 3000
 
 interface Events extends ServiceLifecycleEvents {
   accountsWithBalances: {
@@ -517,7 +517,7 @@ export default class IndexingService extends BaseService<Events> {
 
     const balances = await this.chainService.assetData.getTokenBalances(
       addressNetwork,
-      smartContractAssets?.map(({ contractAddress }) => contractAddress)
+      smartContractAssets?.map(({ contractAddress }) => getShardFromAddress(contractAddress) == getShardFromAddress(addressNetwork.address) ? contractAddress : "")
     )
 
     const listedAssetByAddress = (smartContractAssets ?? []).reduce<{

--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -1,5 +1,5 @@
-import { TransactionRequest as EthersTransactionRequest } from "@ethersproject/abstract-provider"
-import { serialize as serializeEthersTransaction } from "@ethersproject/transactions"
+import { TransactionRequest as EthersTransactionRequest } from "@quais/abstract-provider"
+import { serialize as serializeEthersTransaction } from "@quais/transactions"
 
 import {
   EIP1193Error,
@@ -384,15 +384,15 @@ export default class InternalEthereumProviderService extends BaseService<Events>
   async getCurrentOrDefaultNetworkForOrigin(
     origin: string
   ): Promise<EVMNetwork> {
-    /*const currentNetwork = await this.db.getCurrentNetworkForOrigin(origin)
+    const currentNetwork = await this.db.getCurrentNetworkForOrigin(origin)
     if (!currentNetwork) {
       // If this is a new dapp or the dapp has not implemented wallet_switchEthereumChain
       // use the default network.
       const defaultNetwork = await this.getCurrentInternalNetwork()
       return defaultNetwork
     }
-    return currentNetwork*/
-    return QUAI_NETWORK
+    return currentNetwork
+    //return QUAI_NETWORK
   }
 
   async removePrefererencesForChain(chainId: string): Promise<void> {
@@ -415,9 +415,11 @@ export default class InternalEthereumProviderService extends BaseService<Events>
       throw new Error("Transactions must have a from address for signing.")
     }
 
-    const currentNetwork = await this.getCurrentOrDefaultNetworkForOrigin(
+    /*let currentNetwork = await this.getCurrentOrDefaultNetworkForOrigin(
       origin
-    )
+    )*/
+    const currentNetwork = globalThis.main.store.getState().ui.selectedAccount.network
+
 
     const isRootstock = currentNetwork.chainID === ROOTSTOCK.chainID
 

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -358,6 +358,13 @@ export default class KeyringService extends BaseService<Events> {
     return newKeyring.id
   }
 
+  async exportPrivKey(address: string): Promise<string> {
+    this.requireUnlocked()
+    let keyring = await this.#findKeyring(address)
+    const privKey = keyring.exportPrivateKey(address, "I solemnly swear that I am treating this private key material with great care.")
+    return privKey??"Not found"
+  }
+
   /**
    * Return the source of a given address' keyring if it exists.  If an
    * address does not have a keyring associated with it - returns null.

--- a/background/services/name/resolvers/ens.ts
+++ b/background/services/name/resolvers/ens.ts
@@ -100,6 +100,7 @@ export default function ensResolverFor(
       address,
       network,
     }: AddressOnNetwork): Promise<NameOnNetwork | undefined> {
+      return undefined
       const name = await chainService
         // Hard-coded to ETHEREUM to support ENS names on ETH L2's.
         .providerForNetwork(QUAI_NETWORK)
@@ -109,10 +110,10 @@ export default function ensResolverFor(
         return undefined
       }
 
-      return {
+      /*return {
         name,
         network,
-      }
+      }*/
     },
   }
 }

--- a/background/services/name/resolvers/rns.ts
+++ b/background/services/name/resolvers/rns.ts
@@ -84,6 +84,7 @@ export default function rnsResolver(): NameResolver<"RNS"> {
       address,
       network,
     }: AddressOnNetwork): Promise<NameOnNetwork | undefined> {
+      return undefined
       const reverseRecordHash = utils.namehash(
         `${stripHexPrefix(address)}.addr.reverse`
       )

--- a/background/services/name/resolvers/uns.ts
+++ b/background/services/name/resolvers/uns.ts
@@ -206,6 +206,7 @@ export default function unsResolver(): NameResolver<"UNS"> {
       address,
       network,
     }: AddressOnNetwork): Promise<NameOnNetwork | undefined> {
+      return undefined
       // Get all the records associated with the particular ETH address
       const data = (await reverseLookupAddress(address))?.data
       // Since for a given address you can have multiple UNS records, we just pick the first one

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -39,7 +39,7 @@
     "default_title": "Pelagus",
     "default_popup": "popup.html"
   },
-  "permissions": ["alarms", "storage", "unlimitedStorage", "activeTab", "runtime"],
+  "permissions": ["alarms", "storage", "unlimitedStorage", "activeTab"],
   "background": {
     "service_worker": "background.js"
   }

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -13,6 +13,7 @@
       "lastAccountWarningBody": "Are you sure you want to proceed?",
       "removeAddress": "Remove address",
       "copyAddress": "Copy address",
+      "exportAccount": "Export private key",
       "removeConfirm": "Yes, I want to remove it"
     },
     "notificationPanel": {


### PR DESCRIPTION
Private key export is a feature requested by developers and provider caching slightly decreases request load on the RPC.
Also removed "runtime" permission from manifest.json

In addition, this PR adds an 'Advanced' tab to the send page which allows the user to customize the nonce, gas limit, max fee, and max priority fee (miner tip).