### PR TITLE
Change default account names

### DIFF
--- a/background/redux-slices/accounts.ts
+++ b/background/redux-slices/accounts.ts
@@ -34,14 +34,14 @@ export const enum AccountType {
 }
 
 export const DEFAULT_ACCOUNT_NAMES = [
-  "Phoenix",
-  "Matilda",
-  "Sirius",
-  "Topa",
-  "Atos",
-  "Sport",
-  "Lola",
-  "Foz",
+  "Nautilus",
+  "Poseidon",
+  "Compass",
+  "Calypso",
+  "Marina",
+  "Siren",
+  "Endeavour",
+  "Yawl",
 ]
 
 const availableDefaultNames = [...DEFAULT_ACCOUNT_NAMES]


### PR DESCRIPTION
Went from dog-themed to ocean/boat-themed. 

"Nautilus" - Named after the submarine in Jules Verne's "Twenty Thousand Leagues Under the Sea."
"Poseidon" - The Greek god of the sea.
"Compass" - An essential tool for navigation.
"Calypso" - A sea nymph in Greek mythology, also the name of Jacques Cousteau's research vessel.
"Marina" - A place where boats are docked.
"Siren" - Mythical creatures that lured sailors to their doom, but also a term used in modern boating for warning devices.
"Endeavour" - Named after Captain Cook's research vessel.
"Yawl" - A type of two-masted sailing craft.