### PR TITLE
Bump version to 0.2.2 and remove rc tag

### DIFF
--- a/background/package.json
+++ b/background/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@pelagus/pelagus-background",
-  "version": "0.1.0-pre.0",
-  "description": "Pelagus, the community owned and operated Web3 wallet: api implementation.",
+  "version": "0.2.2",
+  "description": "Pelagus, the community owned and operated Web3 wallet for Quai Network: api implementation.",
   "main": "index.ts",
-  "repository": "git@github.com:thesis/tally-extension.git",
-  "author": "Matt Luongo <matt@thesis.co>",
+  "repository": "git@github.com:PelagusWallet/pelagus-extension.git",
+  "author": "https://pelaguswallet.io",
   "license": "GPL-3.0",
   "keywords": [
     "ethereum",

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Pelagus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The community owned and operated Quai Web3 wallet.",
   "homepage_url": "https://pelaguswallet.io",
   "author": "https://pelaguswallet.io",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@pelagus/pelagus-extension",
   "private": true,
-  "version": "0.1.0-pre.0",
-  "description": "Pelagus, the community owned and operated Web3 wallet.",
+  "version": "0.2.2",
+  "description": "Pelagus, the community owned and operated Web3 wallet for Quai Network.",
   "main": "index.js",
-  "repository": "git@github.com:thesis/tally-extension.git",
-  "author": "Matt Luongo <matt@thesis.co>",
+  "repository": "git@github.com:PelagusWallet/pelagus-extension.git",
+  "author": "https://pelaguswallet.io",
   "license": "GPL-3.0",
   "jest": {
     "setupFiles": [
@@ -63,8 +63,8 @@
     "@fortawesome/fontawesome-free": "^5.15.2",
     "@tallyho/provider-bridge": "0.0.1",
     "@tallyho/provider-bridge-shared": "0.0.1",
-    "@pelagus/pelagus-background": "0.1.0-pre.0",
-    "@pelagus/pelagus-ui": "0.1.0-pre.0",
+    "@pelagus/pelagus-background": "0.2.2 ",
+    "@pelagus/pelagus-ui": "0.2.2",
     "@tallyho/window-provider": "0.0.1",
     "buffer": "^6.0.3",
     "react": "^17.0.2",

--- a/provider-bridge-shared/package.json
+++ b/provider-bridge-shared/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Pelagus, the community owned and operated Web3 wallet: provider bridge to connect the in-page provider with the background script.",
   "main": "index.ts",
-  "repository": "git@github.com:thesis/tally-extension.git",
-  "author": "Greg Nagy <gergo.nagy@tally.cash>",
+  "repository": "git@github.com:PelagusWallet/pelagus-extension.git",
+  "author": "https://pelaguswallet.io",
   "license": "GPL-3.0",
   "keywords": [
     "ethereum",

--- a/provider-bridge/package.json
+++ b/provider-bridge/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Pelagus, the community owned and operated Web3 wallet: provider bridge to connect the in-page provider with the background script.",
   "main": "index.ts",
-  "repository": "git@github.com:thesis/tally-extension.git",
-  "author": "Greg Nagy <gergo.nagy@tally.cash>",
+  "repository": "git@github.com:PelagusWallet/pelagus-extension.git",
+  "author": "https://pelaguswallet.io",
   "license": "GPL-3.0",
   "keywords": [
     "ethereum",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@pelagus/pelagus-ui",
-  "version": "0.1.0-pre.0",
-  "description": "Pelagus, the community owned and operated Web3 wallet: UI package.",
+  "version": "0.2.2",
+  "description": "Pelagus, the community owned and operated Web3 wallet for Quai Network: UI package.",
   "main": "index.ts",
-  "repository": "git@github.com:thesis/tally-extension.git",
-  "author": "Matt Luongo <matt@thesis.co>",
+  "repository": "git@github.com:PelagusWallet/pelagus-extension.git",
+  "author": "https://pelaguswallet.io",
   "license": "GPL-3.0",
   "keywords": [
     "ethereum",
@@ -31,7 +31,7 @@
     "@ledgerhq/devices": "^6.20.0",
     "@reduxjs/toolkit": "^1.6.0",
     "@tallyho/provider-bridge-shared": "0.0.1",
-    "@pelagus/pelagus-background": "0.1.0-pre.0",
+    "@pelagus/pelagus-background": "0.2.2",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.3",

--- a/window-provider/package.json
+++ b/window-provider/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Pelagus, the community owned and operated Web3 wallet: window provider is responsible for creating the in-page object for communication.",
   "main": "index.ts",
-  "repository": "git@github.com:thesis/tally-extension.git",
-  "author": "Greg Nagy <gergo.nagy@tally.cash>",
+  "repository": "git@github.com:PelagusWallet/pelagus-extension.git",
+  "author": "https://pelaguswallet.io",
   "license": "GPL-3.0",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
We've decided to no longer use the 'rc' tag. From now on, Pelagus will have three version numbers: `major release`.`minor release`.`patch`
We will start this versioning system at 0.2.1