### PR TITLE
Reset package.json version to 0.1.0-pre.0 for building and bumped manifest to 0.2.1

### DIFF
--- a/background/package.json
+++ b/background/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pelagus/pelagus-background",
-  "version": "0.2.0-rc.1",
+  "version": "0.1.0-pre.0",
   "description": "Pelagus, the community owned and operated Web3 wallet: api implementation.",
   "main": "index.ts",
   "repository": "git@github.com:thesis/tally-extension.git",

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Pelagus",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The community owned and operated Quai Web3 wallet.",
   "homepage_url": "https://pelaguswallet.io",
   "author": "https://pelaguswallet.io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pelagus/pelagus-extension",
   "private": true,
-  "version": "0.2.0-rc.1",
+  "version": "0.1.0-pre.0",
   "description": "Pelagus, the community owned and operated Web3 wallet.",
   "main": "index.js",
   "repository": "git@github.com:thesis/tally-extension.git",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pelagus/pelagus-ui",
-  "version": "0.2.0-rc.1",
+  "version": "0.1.0-pre.0",
   "description": "Pelagus, the community owned and operated Web3 wallet: UI package.",
   "main": "index.ts",
   "repository": "git@github.com:thesis/tally-extension.git",


### PR DESCRIPTION
Currently, bumping the package.json version to any higher version will cause `yarn install` or `yarn build` to fail with type errors. This is an issue that needs to be fixed. In the meantime, we will reset the version to 0.1.0-pre.0 in the package.json and use the version specified in manifest.json to notate the current version of the extension.