### PR TITLE
Add is pelagus identifier

### DIFF
--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -81,6 +81,8 @@ export default class TallyWindowProvider extends EventEmitter {
 
   connected = false
 
+  isPelagus = true
+
   isTally = true
 
   isMetaMask = false


### PR DESCRIPTION
- Added dummy `isPelagus` boolean to the window-provider for easier extension identification against other extensions.