### PR TITLE
Bugfixes: Better password unlock, better add address, continue button is now send

### DIFF
--- a/background/redux-slices/keyrings.ts
+++ b/background/redux-slices/keyrings.ts
@@ -147,6 +147,10 @@ export const generateNewKeyring = createBackgroundAsyncThunk(
 export const deriveAddress = createBackgroundAsyncThunk(
   "keyrings/deriveAddress",
   async ({signerId: id, shard: shard}: DeriveAddressData) => {
+    if(id == "") {
+      console.log("No signerId provided, skipping derive address")
+      return
+    }
     console.log("Emitting derive address for signerId: " + id + " and shard: " + shard)
     await emitter.emit("deriveAddress", {signerId: id, shard: shard})
   }

--- a/background/services/abilities/index.ts
+++ b/background/services/abilities/index.ts
@@ -156,6 +156,7 @@ export default class AbilitiesService extends BaseService<Events> {
   }
 
   async pollForAbilities(address: NormalizedEVMAddress): Promise<void> {
+    return
     const latestDaylightAbilities = await getDaylightAbilities(address)
     const latestAbilities = normalizeDaylightAbilities(
       latestDaylightAbilities,

--- a/background/services/keyring/index.ts
+++ b/background/services/keyring/index.ts
@@ -420,12 +420,28 @@ export default class KeyringService extends BaseService<Events> {
     //const keyringAddresses = keyring.getAddressesSync()
     let found = false
     let newAddress = ''
+
+    // If There are any hidden addresses, check those first before adding new ones. 
+    for (const [address, isHidden] of Object.entries(this.#hiddenAccounts)) {
+      if (!isHidden) {
+        continue
+      }
+      const shardFromAddress = getShardFromAddress(address)
+      //console.log(`Address: ${address}, isHidden: ${isHidden} Shard: ${shardFromAddress}`);
+      if (shardFromAddress !== undefined) {
+        // Check if address is in correct shard
+        if (shardFromAddress === shard && keyring.getAddressesSync().includes(address)) {
+          found = true
+          delete this.#hiddenAccounts[address]
+          newAddress = address
+          console.log("Found hidden address in shard %s %s", shard, address)
+          break
+        }
+      }
+    }
+
     while(!found) {
-      // If There are any hidden addresses, show those first before adding new ones. (Not being done anymore)
-      newAddress =
-        /*keyringAddresses.find(
-          (address) => this.#hiddenAccounts[address] === true
-        ) ??*/ keyring.addAddressesSync(1)[0]
+      newAddress = keyring.addAddressesSync(1)[0]
       const shardFromAddress = getShardFromAddress(newAddress)
       if (shardFromAddress !== undefined) {
         // Check if address is in correct shard

--- a/ui/_locales/en/messages.json
+++ b/ui/_locales/en/messages.json
@@ -810,7 +810,7 @@
     "sendAsset": "Send Asset",
     "assetAmount": "Asset / Amount",
     "sendTo": "Send To:",
-    "sendButton": "Continue",
+    "sendButton": "Send",
     "receiveAddress": "Receive address",
     "sendToContractWarning": "This is a contract address, sending assets could result in loss of funds.",
     "pages": {

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanel.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanel.tsx
@@ -5,10 +5,15 @@ import AccountsNotificationPanelAccounts from "./AccountsNotificationPanelAccoun
 
 type Props = {
   onCurrentAddressChange: (address: string) => void
+  setSelectedAccountSigner: (address: string) => void
+  selectedAccountSigner: string
 }
 
 export default function AccountsNotificationPanel({
   onCurrentAddressChange,
+  setSelectedAccountSigner,
+  selectedAccountSigner,
+
 }: Props): ReactElement {
   const { t } = useTranslation()
 
@@ -18,6 +23,8 @@ export default function AccountsNotificationPanel({
     >
       <AccountsNotificationPanelAccounts
         onCurrentAddressChange={onCurrentAddressChange}
+        setSelectedAccountSigner={setSelectedAccountSigner}
+        selectedAccountSigner={selectedAccountSigner}
       />
     </SharedSlideUpMenuPanel>
   )

--- a/ui/components/Keyring/KeyringUnlock.tsx
+++ b/ui/components/Keyring/KeyringUnlock.tsx
@@ -23,6 +23,7 @@ export default function KeyringUnlock({
   const { t: tShared } = useTranslation("translation", { keyPrefix: "shared" })
   const [password, setPassword] = useState("")
   const [errorMessage, setErrorMessage] = useState("")
+  const [unlockSuccess, setUnlockSuccess] = useState(false)
   const isDappPopup = useIsDappPopup()
   const history: {
     entries?: { pathname: string }[]
@@ -38,15 +39,18 @@ export default function KeyringUnlock({
       history.goBack()
       dispatch(setSnackbarMessage(t("snackbar")))
     }
-  }, [history, areKeyringsUnlocked, dispatch, t])
+  }, [history, areKeyringsUnlocked, dispatch, t, unlockSuccess])
 
   const dispatchUnlockWallet = async (
     event: React.FormEvent<HTMLFormElement>
   ): Promise<void> => {
     event.preventDefault()
-    await dispatch(unlockKeyrings(password))
+    const { success } = await dispatch(unlockKeyrings(password))
     // If keyring was unable to unlock, display error message
-    setErrorMessage(t("error.incorrect"))
+    if(!success) {
+      setErrorMessage(t("error.incorrect"))
+    }
+    setUnlockSuccess(success)
   }
 
   const handleReject = async () => {

--- a/ui/components/TopMenu/TopMenu.tsx
+++ b/ui/components/TopMenu/TopMenu.tsx
@@ -28,6 +28,7 @@ export default function TopMenu(): ReactElement {
   const [isProtocolListOpen, setIsProtocolListOpen] = useState(false)
   const [isNotificationsOpen, setIsNotificationsOpen] = useState(false)
   const [isBonusProgramOpen, setIsBonusProgramOpen] = useState(false)
+  const [selectedAccountSigner, setSelectedAccountSigner] = useState("")
 
   const [isActiveDAppConnectionInfoOpen, setIsActiveDAppConnectionInfoOpen] =
     useState(false)
@@ -132,6 +133,8 @@ export default function TopMenu(): ReactElement {
       >
         <AccountsNotificationPanel
           onCurrentAddressChange={() => setIsNotificationsOpen(false)}
+          setSelectedAccountSigner={setSelectedAccountSigner}
+          selectedAccountSigner={selectedAccountSigner}
         />
       </SharedSlideUpMenu>
       {isEnabled(FeatureFlags.ENABLE_UPDATED_DAPP_CONNECTIONS) && (

--- a/ui/pages/Onboarding/Tabbed/SetPassword.tsx
+++ b/ui/pages/Onboarding/Tabbed/SetPassword.tsx
@@ -36,7 +36,13 @@ export default function SetPassword(): JSX.Element {
     if (nextPage && areKeyringsUnlocked) {
       history.replace(nextPage)
     }
-  }, [areKeyringsUnlocked, history, nextPage, passwordCompleted])
+  }, [areKeyringsUnlocked, history, nextPage])
+
+  useEffect( () => {
+    if (nextPage && passwordCompleted) {
+      history.replace(nextPage)
+    }
+  }, [passwordCompleted, history, nextPage])
 
   const validatePassword = (): boolean => {
     if (password.length < 8) {
@@ -62,8 +68,15 @@ export default function SetPassword(): JSX.Element {
 
   const dispatchCreatePassword = (): void => {
     if (validatePassword()) {
-      dispatch(createPassword(password)).then(() => {
-        setPasswordCompleted(!passwordCompleted)
+      dispatch(createPassword(password)).then(async () => {
+        const { success } = await dispatch(unlockKeyrings(password))
+        if(success) {
+          setPasswordCompleted(true)
+        } else {
+          setPasswordCompleted(false)
+          setPasswordErrorMessage(t("keyring.setPassword.error.noMatch"))
+        }
+        
       })
     }
   }


### PR DESCRIPTION
Bugfixes:

- Setting password and unlocking with password sometimes wouldn't work, this is now fixed
- No more polling for abilities
- Deriving a new address (Add Address button) now adds to the correct wallet when there is more than 1 wallet (imported wallets)
- Deriving a new address now goes over 'skipped' addresses when searching for the right shard
- "Continue" button on send transaction page is now "Send"