### PR TITLE
Revert cointype

### DIFF
--- a/background/constants/networks.ts
+++ b/background/constants/networks.ts
@@ -306,7 +306,7 @@ export const QUAI_NETWORK: EVMNetwork = {
   chainID: "9000",
   family: "EVM",
   chains: DEFAULT_QUAI_TESTNET.chains,
-  derivationPath: "m/44'/994'/0'/0",
+  derivationPath: "m/44'/60'/0'/0",
   isQuai: true,
 }
 
@@ -316,7 +316,7 @@ export const QUAI_NETWORK_LOCAL: EVMNetwork = {
   chainID: "1337",
   family: "EVM",
   chains: DEFAULT_QUAI_LOCAL.chains,
-  derivationPath: "m/44'/994'/0'/0",
+  derivationPath: "m/44'/60'/0'/0",
   isQuai: true,
 }
 

--- a/background/services/ledger/index.ts
+++ b/background/services/ledger/index.ts
@@ -111,7 +111,7 @@ type Events = ServiceLifecycleEvents & {
   usbDeviceCount: number
 }
 
-export const idDerivationPath = "44'/994'/0'/0/0"
+export const idDerivationPath = "44'/60'/0'/0/0"
 
 async function deriveAddressOnLedger(path: string, eth: Eth) {
   const derivedIdentifiers = await eth.getAddress(path)

--- a/rfb/rfb-5-control-compatile-addresses.md
+++ b/rfb/rfb-5-control-compatile-addresses.md
@@ -12,7 +12,7 @@ Currently, the code base assumes that a given address is always controlled by
 the same underlying key, keyring, or external device, even if it is on a
 different network. For regular keys, in practice, this is a fair assumption: if
 Bob has a mnemonic that can sign for address `0x0abc` with a derivation path of
-`44'/994'/0'/0/0`, it's extremely unlikely that Bob will ALSO have a different
+`44'/60'/0'/0/0`, it's extremely unlikely that Bob will ALSO have a different
 key that can sign for the same address but at derivation path
 `44'/137'/0'/0/0`. For this to happen, Bob would more or less have to have two
 different mnemonics that derive the same private key at two different
@@ -21,7 +21,7 @@ derivation paths!
 The assumption, however, falls apart when it comes to accounts that are not
 derived or controlled directly by in-memory private keys, however. For example,
 if Bob is viewing the Ethereum network and has a key stored on a Ledger for
-`0x0abc` at `44'/994'/0'/0/0` and can sign a transaction for that address, they
+`0x0abc` at `44'/60'/0'/0/0` and can sign a transaction for that address, they
 can interact with everything as expected--dApps, etc. If Bob switches to the
 Rootstock network, on the other hand, and they control that key using a Ledger,
 Ledger itself might require a different app to sign a transaction for that key

--- a/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
+++ b/ui/components/Onboarding/OnboardingDerivationPathSelect.tsx
@@ -31,11 +31,11 @@ export enum DefaultPathIndex {
 // TODO make this network specific
 const defaultDerivationPaths: Record<DefaultPathIndex, DerivationPath> = {
   [DefaultPathIndex.ledgerLive]: {
-    value: "m/44'/994'/x'/0/0",
+    value: "m/44'/60'/x'/0/0",
     label: "ledger.derivationPaths.ledgerLive",
   },
   [DefaultPathIndex.bip44]: {
-    value: "m/44'/994'/0'/0",
+    value: "m/44'/60'/0'/0",
     label: "ledger.derivationPaths.bip44",
   },
   [DefaultPathIndex.ethTestnet]: {
@@ -43,7 +43,7 @@ const defaultDerivationPaths: Record<DefaultPathIndex, DerivationPath> = {
     label: "ledger.derivationPaths.ethTestnet",
   },
   [DefaultPathIndex.ledgerLegacy]: {
-    value: "m/44'/994'/0'",
+    value: "m/44'/60'/0'",
     label: "ledger.derivationPaths.ledgerLegacy",
     hideActiveValue: true,
   },

--- a/ui/pages/Onboarding/Tabbed/ImportSeed.tsx
+++ b/ui/pages/Onboarding/Tabbed/ImportSeed.tsx
@@ -31,7 +31,7 @@ export default function ImportSeed(props: Props): ReactElement {
   const [recoveryPhrase, setRecoveryPhrase] = useState("")
   const [errorMessage, setErrorMessage] = useState("")
   const [path, setPath] = useState<string>(
-    selectedNetwork.derivationPath ?? "m/44'/994'/0'/0"
+    selectedNetwork.derivationPath ?? "m/44'/60'/0'/0"
   )
   const [isImporting, setIsImporting] = useState(false)
 

--- a/ui/pages/Onboarding/Tabbed/NewSeed.tsx
+++ b/ui/pages/Onboarding/Tabbed/NewSeed.tsx
@@ -70,7 +70,7 @@ export default function NewSeed(): ReactElement {
 
   const showNewSeedPhrase = () => {
     dispatch(
-      generateNewKeyring(selectedNetwork.derivationPath ?? "m/44'/994'/0'/0")
+      generateNewKeyring(selectedNetwork.derivationPath ?? "m/44'/60'/0'/0")
     ).then(() => history.push(NewSeedRoutes.REVIEW_SEED))
   }
 
@@ -83,6 +83,7 @@ export default function NewSeed(): ReactElement {
       importKeyring({
         mnemonic: verifiedMnemonic.join(" "),
         source: "internal",
+        path: selectedNetwork.derivationPath ?? "m/44'/60'/0'/0",
       })
     ).then(() => history.push(OnboardingRoutes.ONBOARDING_COMPLETE))
   }

--- a/ui/pages/Onboarding/VerifySeed/VerifySeedSuccess.tsx
+++ b/ui/pages/Onboarding/VerifySeed/VerifySeedSuccess.tsx
@@ -43,7 +43,7 @@ function VerifySeedSuccess({
             importKeyring({
               mnemonic: mnemonic.join(" "),
               source: "internal",
-              path: selectedNetwork.derivationPath ?? "m/44'/994'/0'/0",
+              path: selectedNetwork.derivationPath ?? "m/44'/60'/0'/0",
             })
           )
           history.push(nextPage)


### PR DESCRIPTION
https://github.com/PelagusWallet/hd-keyring/pull/4 was never merged so everyone created a wallet for the default keyring cointype (60). In order for the import to work, we have to revert the cointype back to 60. We can change the cointype to 994 for mainnet.