### PR TITLE
Add quai_nodeLocation, eth_chanId and eth_requestAccounts to supported methods

### DIFF
--- a/background/services/internal-ethereum-provider/index.ts
+++ b/background/services/internal-ethereum-provider/index.ts
@@ -195,6 +195,10 @@ export default class InternalEthereumProviderService extends BaseService<Events>
         return toHexChainID(
           (await this.getCurrentOrDefaultNetworkForOrigin(origin)).chainID
         )
+      case "eth_chainId":
+        return toHexChainID(
+          (await this.getCurrentOrDefaultNetworkForOrigin(origin)).chainID
+        )
       case "quai_blockNumber":
       case "quai_call":
       case "quai_estimateGas":
@@ -224,6 +228,7 @@ export default class InternalEthereumProviderService extends BaseService<Events>
       case "quai_newBlockFilter":
       case "quai_newFilter":
       case "quai_newPendingTransactionFilter":
+      case "quai_nodeLocation":
       case "quai_protocolVersion":
       case "quai_sendRawTransaction":
       case "quai_subscribe":

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -210,7 +210,8 @@ export default class ProviderBridgeService extends BaseService<Events> {
       response.result = null
     } else if (
       event.request.method === "quai_chainId" ||
-      event.request.method === "net_version"
+      event.request.method === "net_version" || 
+      event.request.method === "eth_chainId"
     ) {
       // we need to send back the chainId and net_version (a deprecated
       // precursor to eth_chainId) independent of dApp permission if we want to
@@ -233,7 +234,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
         event.request.params,
         origin
       )
-    } else if (event.request.method === "quai_requestAccounts") {
+    } else if (event.request.method === "quai_requestAccounts" || event.request.method == "eth_requestAccounts") {
       // if it's external communication AND the dApp does not have permission BUT asks for it
       // then let's ask the user what he/she thinks
 
@@ -463,6 +464,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
     try {
       switch (method) {
         case "quai_requestAccounts":
+        case "eth_requestAccounts":
         case "quai_accounts":
           return [enablingPermission.accountAddress]
         case "quai_signTypedData":

--- a/provider-bridge/index.ts
+++ b/provider-bridge/index.ts
@@ -20,6 +20,7 @@ export function connectProviderBridge(): void {
       // if dapp wants to connect let's grab its details
       if (
         event.data.request.method === "quai_requestAccounts" ||
+        event.data.request.method === "eth_requestAccounts" ||
         event.data.request.method === "wallet_addEthereumChain"
       ) {
         const faviconElements: NodeListOf<HTMLLinkElement> =

--- a/window-provider/index.ts
+++ b/window-provider/index.ts
@@ -240,6 +240,7 @@ export default class TallyWindowProvider extends EventEmitter {
         break
 
       case "quai_chainId":
+      case "eth_chainId":
       case "net_version":
         if (
           typeof result === "string" &&
@@ -250,6 +251,8 @@ export default class TallyWindowProvider extends EventEmitter {
         break
 
       case "quai_accounts":
+      case "eth_accounts":
+      case "eth_requestAccounts":
       case "quai_requestAccounts":
         if (Array.isArray(result) && result.length !== 0) {
           this.handleAddressChange(result)


### PR DESCRIPTION
The `eth` namespace support was added to two methods that Galxe asks for.