### PR TITLE
fix: change #fff color text to var(--green-40) on connect to dApp view

### DIFF
--- a/ui/pages/DAppConnect/DAppConnectPage.tsx
+++ b/ui/pages/DAppConnect/DAppConnectPage.tsx
@@ -110,7 +110,7 @@ export default function DAppConnectPage({
           margin-left: 5px;
         }
         .permissions_list_title {
-          color: #fff;
+          color: var(--green-40);
           margin-bottom: 8px;
           margin-top: 15px;
           margin-left: 0px;


### PR DESCRIPTION
This text was already colored with #fff when the Pelagus extension was forked at v0.38.1. I changed it to var(--green-40), which is the most commonly used variable for this type of text