### PR TITLE
Await grant permission event handlers

### DIFF
--- a/background/redux-slices/dapp.ts
+++ b/background/redux-slices/dapp.ts
@@ -36,7 +36,7 @@ export const emitter = new Emittery<Events>()
 export const grantPermission = createBackgroundAsyncThunk(
   "dapp-permission/permissionGrant",
   async (permission: PermissionRequest) => {
-    emitter.emit("grantPermission", {
+    await emitter.emit("grantPermission", {
       ...permission,
     })
     return permission

--- a/background/redux-slices/dapp.ts
+++ b/background/redux-slices/dapp.ts
@@ -36,9 +36,7 @@ export const emitter = new Emittery<Events>()
 export const grantPermission = createBackgroundAsyncThunk(
   "dapp-permission/permissionGrant",
   async (permission: PermissionRequest) => {
-    await emitter.emit("grantPermission", {
-      ...permission,
-    })
+    await emitter.emit("grantPermission", permission)
     return permission
   }
 )

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -385,7 +385,14 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
   async grantPermission(permission: PermissionRequest): Promise<void> {
     // FIXME proper error handling if this happens - should not tho
-    if (permission.state !== "allow" || !permission.accountAddress) return
+    if (permission.state !== "allow") {
+      console.error(`Invalid state received when granting permission. Expected 'allow' but got '${permission.state}'.`)
+      return
+    }
+    if (!permission.accountAddress) {
+      console.error("Empty account address received when granting permission.")
+      return
+    }
 
     await this.db.setPermission(permission)
 
@@ -397,7 +404,12 @@ export default class ProviderBridgeService extends BaseService<Events> {
 
   async denyOrRevokePermission(permission: PermissionRequest): Promise<void> {
     // FIXME proper error handling if this happens - should not tho
-    if (permission.state !== "deny" || !permission.accountAddress) {
+    if (permission.state !== "deny") {
+      console.error(`Invalid state received when denying permission. Expected 'deny' but got '${permission.state}'.`)
+      return
+    }
+    if (!permission.accountAddress) {
+      console.error("Empty account address received when denying permission.")
       return
     }
 


### PR DESCRIPTION
### Bug Description
Occasionally, when a user navigates to a dapp and **immediately** attempts to connect and grant permission to Pelagus, the connection does not register. It can take several attempts after the silent failure to successful connect Pelagus.

### Solution
Wait for all `grantPermission` event handlers to resolve and add additional logging to uncover silent failure reason during grant flow.