### PR TITLE
ISSUE-150/143: fixes Pelagus Wallet never initialized after signup flow

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -1491,13 +1491,6 @@ export default class Main extends BaseService<never> {
 
       this.store.dispatch(setKeyringToVerify(generated))
     })
-
-    keyringSliceEmitter.on(
-      "importKeyring",
-      async ({ mnemonic, path, source }) => {
-        await this.keyringService.importKeyring(mnemonic, source, path)
-      }
-    )
   }
 
   async connectInternalEthereumProviderService(): Promise<void> {
@@ -1982,6 +1975,18 @@ export default class Main extends BaseService<never> {
 
   async exportPrivKey(address: string): Promise<string> {
     return this.keyringService.exportPrivKey(address)
+  }
+
+  async importSigner({
+    mnemonic,
+    path,
+    source,
+  }: {
+    mnemonic: string
+    path?: string
+    source: "import" | "internal"
+  }): Promise<string | null> {
+    return this.keyringService.importKeyring(mnemonic, source, path)
   }
 
   async getActivityDetails(txHash: string): Promise<ActivityDetail[]> {


### PR DESCRIPTION
It appears that the keyring service, is being blocked during registration. This blocking likely occurs when the extension remains inactive for a period of time, triggering an automatic block on the keyring service.

Upon pressing the submit button after verifying the passphrase, a function is called to interact with the state. This function, in turn, calls another function to check whether the keyring service is unlocked. In our current implementation, an error is returned at this stage, but we are not handling it at the UI level. As a consequence, users encounter an incorrect screen, rendering the wallet inaccessible.

A bool flag was introduced, which is checked in the components, if an error occurs we emit it, only because of the keyring service. But we are already processing locking event at this moment and the user should see the password entry screen.