### PR TITLE
ISSUE-148: fixes token allowance text is same color as background

### DIFF
--- a/ui/components/Signing/SignatureDetails/TransactionSignatureDetails/TransactionSignatureSummary/SpendApprovalSummary.tsx
+++ b/ui/components/Signing/SignatureDetails/TransactionSignatureDetails/TransactionSignatureSummary/SpendApprovalSummary.tsx
@@ -296,7 +296,7 @@ export default function SpendApprovalSummary({
             margin-top: 24px;
           }
           .spend_amount {
-            color: #fff;
+            color: var(--green-40);
             font-size: 16px;
             line-height: 24px;
           }


### PR DESCRIPTION
Changed the permission text from white to green-40 (the main dark color that is used in the project).