### PR TITLE
ISSUE-152: fixes add address doesn't redirect user back to add address screen

### DIFF
--- a/background/redux-slices/ui.ts
+++ b/background/redux-slices/ui.ts
@@ -25,6 +25,8 @@ export const defaultSettings = {
 export type UIState = {
   selectedAccount: AddressOnNetwork
   showingActivityDetailID: string | null
+  showingAccountsModal: boolean
+  showingAddAccountModal: boolean
   initializationLoadingTimeExpired: boolean
   // FIXME: Move these settings to preferences service db
   settings: {
@@ -62,6 +64,8 @@ export const emitter = new Emittery<Events>()
 
 export const initialState: UIState = {
   showingActivityDetailID: null,
+  showingAccountsModal: false,
+  showingAddAccountModal: false,
   selectedAccount: {
     address: "",
     network: QUAI_NETWORK,
@@ -133,6 +137,20 @@ const uiSlice = createSlice({
       ...state,
       showingActivityDetailID: transactionID,
     }),
+    setShowingAccountsModal: (
+      state,
+      { payload: isShowingAccountsModal }: { payload: boolean }
+    ): UIState => ({
+      ...state,
+      showingAccountsModal: isShowingAccountsModal,
+    }),
+    setShowingAddAccountModal: (
+      state,
+      { payload: isShowingAddAccountModal }: { payload: boolean }
+    ): UIState => ({
+      ...state,
+      showingAddAccountModal: isShowingAddAccountModal,
+    }),
     setSelectedAccount: (
       immerState,
       { payload: addressNetwork }: { payload: AddressOnNetwork }
@@ -202,6 +220,8 @@ const uiSlice = createSlice({
 
 export const {
   setShowingActivityDetail,
+  setShowingAccountsModal,
+  setShowingAddAccountModal,
   initializationLoadingTimeHitLimit,
   toggleHideDust,
   toggleTestNetworks,
@@ -402,6 +422,16 @@ export const selectShowAnalyticsNotification = createSelector(
 export const selectSlippageTolerance = createSelector(
   selectUI,
   (ui) => ui.slippageTolerance
+)
+
+export const selectShowingAccountsModal = createSelector(
+  selectUI,
+  (ui) => ui.showingAccountsModal
+)
+
+export const selectShowingAddAccountModal = createSelector(
+  selectUI,
+  (ui) => ui.showingAddAccountModal
 )
 
 export const selectInitializationTimeExpired = createSelector(

--- a/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
+++ b/ui/components/AccountsNotificationPanel/AccountsNotificationPanelAccounts.tsx
@@ -6,8 +6,10 @@ import React, {
   useState,
 } from "react"
 import {
+  selectShowingAddAccountModal,
   setNewSelectedAccount,
-  setSelectedAccount,
+  setShowingAccountsModal,
+  setShowingAddAccountModal,
   setSnackbarMessage,
   updateSignerTitle,
 } from "@pelagus/pelagus-background/redux-slices/ui"
@@ -43,7 +45,6 @@ import {
 } from "../../hooks"
 import SharedAccountItemSummary from "../Shared/SharedAccountItemSummary"
 import AccountItemOptionsMenu from "../AccountItem/AccountItemOptionsMenu"
-import { i18n } from "../../_locales/i18n"
 import SharedIcon from "../Shared/SharedIcon"
 import SharedDropdown from "../Shared/SharedDropDown"
 import SharedSlideUpMenu from "../Shared/SharedSlideUpMenu"
@@ -68,7 +69,6 @@ function WalletTypeHeader({
   signerId,
   setShard,
   addAddressSelected,
-  setAddAddressSelected,
   updateCustomOrder,
   updateUseCustomOrder,
   setSelectedAccountSigner,
@@ -81,7 +81,6 @@ function WalletTypeHeader({
   path?: string | null
   setShard: (shard: string) => void
   addAddressSelected: boolean
-  setAddAddressSelected: (selected: boolean) => void
   updateCustomOrder: (address: string[], signerId: string) => void
   updateUseCustomOrder: (useOrder: boolean, signerId: string) => void
   setSelectedAccountSigner: (signerId: string) => void
@@ -118,7 +117,7 @@ function WalletTypeHeader({
 
   const handleShardSelection = (selectedShard: string) => {
     setShard(selectedShard)
-    setAddAddressSelected(false)
+    dispatch(setShowingAddAccountModal(false))
     // Call other required functions like onClickAddAddress
   }
   useEffect(() => {
@@ -127,7 +126,8 @@ function WalletTypeHeader({
         setShowShardMenu(true)
       } else {
         history.push("/keyring/unlock")
-        setAddAddressSelected(false)
+        dispatch(setShowingAddAccountModal(true))
+        dispatch(setShowingAccountsModal(true))
       }
     }
   }, [addAddressSelected])
@@ -192,7 +192,7 @@ function WalletTypeHeader({
         close={(e) => {
           e.stopPropagation()
           setShowShardMenu(false)
-          setAddAddressSelected(false)
+          dispatch(setShowingAddAccountModal(false))
         }}
         customStyles={{
           display: "flex",
@@ -223,7 +223,7 @@ function WalletTypeHeader({
             onClick={() => {
               onClickAddAddress && onClickAddAddress()
               setShowShardMenu(false)
-              setAddAddressSelected(false)
+              dispatch(setShowingAddAccountModal(false))
             }}
           >
             Confirm
@@ -493,7 +493,9 @@ export default function AccountsNotificationPanelAccounts({
     shard.current = newShard
   }
 
-  const [addAddressSelected, setAddAddressSelected] = useState(false)
+  const isShowingAddAccountModal = useBackgroundSelector(
+    selectShowingAddAccountModal
+  )
 
   const selectedAccountAddress =
     useBackgroundSelector(selectCurrentAccount).address
@@ -712,8 +714,7 @@ export default function AccountsNotificationPanelAccounts({
                             }
                           : undefined
                       }
-                      addAddressSelected={addAddressSelected}
-                      setAddAddressSelected={setAddAddressSelected}
+                      addAddressSelected={isShowingAddAccountModal}
                       updateCustomOrder={updateCustomOrder}
                       updateUseCustomOrder={updateUseCustomOrder}
                       setSelectedAccountSigner={setSelectedAccountSigner}
@@ -798,9 +799,7 @@ export default function AccountsNotificationPanelAccounts({
           size="medium"
           iconSmall="add"
           iconPosition="left"
-          onClick={() => {
-            setAddAddressSelected(true)
-          }}
+          onClick={() => dispatch(setShowingAddAccountModal(true))}
         >
           {t("accounts.notificationPanel.addAddress")}
         </SharedButton>

--- a/ui/components/Keyring/KeyringUnlock.tsx
+++ b/ui/components/Keyring/KeyringUnlock.tsx
@@ -3,7 +3,11 @@ import { useHistory } from "react-router-dom"
 import { unlockKeyrings } from "@pelagus/pelagus-background/redux-slices/keyrings"
 import { rejectTransactionSignature } from "@pelagus/pelagus-background/redux-slices/transaction-construction"
 import { useTranslation } from "react-i18next"
-import { setSnackbarMessage } from "@pelagus/pelagus-background/redux-slices/ui"
+import {
+  setShowingAccountsModal,
+  setShowingAddAccountModal,
+  setSnackbarMessage,
+} from "@pelagus/pelagus-background/redux-slices/ui"
 import {
   useBackgroundDispatch,
   useAreKeyringsUnlocked,
@@ -86,6 +90,9 @@ export default function KeyringUnlock({
   }
 
   const handleCancel = () => {
+    dispatch(setShowingAccountsModal(false))
+    dispatch(setShowingAddAccountModal(false))
+
     if (isDappPopup) {
       handleReject()
     } else {

--- a/ui/pages/Wallet.tsx
+++ b/ui/pages/Wallet.tsx
@@ -17,6 +17,8 @@ import { NETWORKS_SUPPORTING_NFTS } from "@pelagus/pelagus-background/nfts"
 import {
   selectShowAnalyticsNotification,
   selectShowUnverifiedAssets,
+  selectShowingAccountsModal,
+  setShowingAccountsModal,
 } from "@pelagus/pelagus-background/redux-slices/ui"
 import { CompleteAssetAmount } from "@pelagus/pelagus-background/redux-slices/accounts"
 import {
@@ -39,10 +41,13 @@ import NFTListCurrentWallet from "../components/NFTs/NFTListCurrentWallet"
 import WalletHiddenAssets from "../components/Wallet/WalletHiddenAssets"
 import SharedButton from "../components/Shared/SharedButton"
 import SharedIcon from "../components/Shared/SharedIcon"
+import SharedSlideUpMenu from "../components/Shared/SharedSlideUpMenu"
+import AccountsNotificationPanel from "../components/AccountsNotificationPanel/AccountsNotificationPanel"
 
 export default function Wallet(): ReactElement {
   const { t } = useTranslation()
   const [panelNumber, setPanelNumber] = useState(0)
+  const [selectedAccountSigner, setSelectedAccountSigner] = useState("")
 
   const dispatch = useBackgroundDispatch()
   const history = useHistory()
@@ -52,6 +57,9 @@ export default function Wallet(): ReactElement {
   const claimState = useBackgroundSelector((state) => state.claim)
   const selectedNetwork = useBackgroundSelector(selectCurrentNetwork)
   const showUnverifiedAssets = useBackgroundSelector(selectShowUnverifiedAssets)
+  const isShowingAccountsModal = useBackgroundSelector(
+    selectShowingAccountsModal
+  )
 
   useEffect(() => {
     dispatch(
@@ -214,6 +222,21 @@ export default function Wallet(): ReactElement {
             )}
           </div>
         </div>
+
+        <SharedSlideUpMenu
+          isOpen={isShowingAccountsModal}
+          close={() => {
+            dispatch(setShowingAccountsModal(false))
+          }}
+        >
+          <AccountsNotificationPanel
+            onCurrentAddressChange={() =>
+              dispatch(setShowingAccountsModal(false))
+            }
+            setSelectedAccountSigner={setSelectedAccountSigner}
+            selectedAccountSigner={selectedAccountSigner}
+          />
+        </SharedSlideUpMenu>
       </div>
       <style jsx>
         {`


### PR DESCRIPTION
Since modals are not separate pages and it was difficult to open them in different places, variables were added to the state, with the help of which you can open these modal windows anywhere.

Unused imports were also removed.