### PR TITLE
ISSUE-171: Invalid BigNumber casting when polling for latest block

### DIFF
--- a/background/services/chain/utils/index.ts
+++ b/background/services/chain/utils/index.ts
@@ -67,12 +67,9 @@ export function blockFromProviderBlock(
     baseFeePerGas?: string
   }
 
-  let blockNumber: string
-  if (Array.isArray(gethResult.number)) {
-    blockNumber = gethResult.number[gethResult.number.length - 1]
-  } else {
-    blockNumber = gethResult.number
-  }
+  let blockNumber: string = Array.isArray(gethResult.number)
+    ? gethResult.number[gethResult.number.length - 1]
+    : gethResult.number
 
   return {
     hash: gethResult.hash,

--- a/background/services/chain/utils/index.ts
+++ b/background/services/chain/utils/index.ts
@@ -67,9 +67,16 @@ export function blockFromProviderBlock(
     baseFeePerGas?: string
   }
 
+  let blockNumber: string
+  if (Array.isArray(gethResult.number)) {
+    blockNumber = gethResult.number[gethResult.number.length - 1]
+  } else {
+    blockNumber = gethResult.number
+  }
+
   return {
     hash: gethResult.hash,
-    blockHeight: BigNumber.from(gethResult.number).toNumber(),
+    blockHeight: BigNumber.from(blockNumber).toNumber(),
     parentHash: gethResult.parentHash,
     // PoS networks will not have block difficulty.
     difficulty: gethResult.difficulty ? BigInt(gethResult.difficulty) : 0n,


### PR DESCRIPTION
gethResult.number can be a string or an array of strings. If array we get the zone index from it.