### PR TITLE
Handle private key undefined state in selectPrivateKeyWalletsByAddress function

### DIFF
--- a/background/redux-slices/selectors/keyringsSelectors.ts
+++ b/background/redux-slices/selectors/keyringsSelectors.ts
@@ -46,9 +46,11 @@ export const selectKeyringsByAddresses = createSelector(
 export const selectPrivateKeyWalletsByAddress = createSelector(
   (state: RootState) => state.keyrings.privateKeys,
   (privateKeys): { [address: HexString]: PrivateKey } =>
-    Object.fromEntries(
-      privateKeys.map((wallet) => [wallet.addresses[0], wallet])
-    )
+    !privateKeys
+      ? {}
+      : Object.fromEntries(
+          privateKeys.map((wallet) => [wallet.addresses[0], wallet])
+        )
 )
 
 export const selectSourcesByAddress = createSelector(


### PR DESCRIPTION
This is a hot fix patch to provide a fallback for private keys array value for those updating their existing version of pelagus.