### PR TITLE
GA-ISSUE 217: [Activity]: When trying to open the transaction details, a blank page appears with a "Return to Home" button

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -751,6 +751,8 @@ export default class Main extends BaseService<never> {
       addressNetwork.network,
       txHash
     )
+    if (!transaction) return
+
     const enrichedTransaction = await this.enrichmentService.enrichTransaction(
       transaction,
       2
@@ -1608,6 +1610,8 @@ export default class Main extends BaseService<never> {
       addressNetwork.network,
       txHash
     )
+    if (!transaction) return []
+
     const enrichedTransaction = await this.enrichmentService.enrichTransaction(
       transaction,
       2

--- a/ui/components/Wallet/WalletActivityDetails.tsx
+++ b/ui/components/Wallet/WalletActivityDetails.tsx
@@ -193,7 +193,7 @@ export default function WalletActivityDetails(
         />
       </div>
       <ul>
-        {details.length ? (
+        {details?.length ? (
           <></>
         ) : (
           Array.from({ length: 7 }).map(() => (
@@ -203,7 +203,7 @@ export default function WalletActivityDetails(
             />
           ))
         )}
-        {details.map(({ assetIconUrl, label, value }) => {
+        {details?.map(({ assetIconUrl, label, value }) => {
           return (
             <DetailRowItem
               key={label}

--- a/ui/pages/SingleAsset.tsx
+++ b/ui/pages/SingleAsset.tsx
@@ -40,7 +40,9 @@ const MAX_SYMBOL_LENGTH = 10
 export default function SingleAsset(): ReactElement {
   const { t } = useTranslation()
   const location = useLocation<AnyAsset>()
-  const locationAsset = location.state
+  const currentAccount = useBackgroundSelector(selectCurrentAccount)
+  const locationAsset = location.state ?? currentAccount.network.baseAsset
+
   const { symbol } = locationAsset
   const contractAddress =
     "contractAddress" in locationAsset


### PR DESCRIPTION
1. (if sending crossshard transactions many times) There was a problem with receiving the transaction. At some points, the transaction data could not be read from the chain. Therefore, additional logic was written to retrieve transaction information from local storage.
But in this case, when we got the transaction data from the local storage, we didn't return anything from the function to the component, because of the wrong condition in the if.
The flow was changed: if the transaction still could not be found and get its data from the chain, I go to the local db and get the cached transaction and return it to the component.

2. (when you go to send after unlock) the data was transferred through the navigation state, so undefined came into the component and we could not work with it. So the logic of getting data from the state and not from the navigation was added (according to examples of how it is done in other components)