### PR TITLE
Increase wallet provider method coverage

### DIFF
--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -568,6 +568,7 @@ export default class ProviderBridgeService extends BaseService<Events> {
             showExtensionPopup(AllowedQueryParamPage.personalSignData)
           )
         case "quai_sendTransaction":
+        case "eth_sendTransaction":
           // TODO check this checkPermissionSignTransaction function in future
           checkPermissionSignTransaction(
             (params[0] as QuaiTransactionRequest).chainId,


### PR DESCRIPTION
Add support for `eth_sendTransaction`, `wallet_requestPermissions`, and `wallet_getPermissions` which allows for end to end wagmi development. This is possible because `eth_sendTransaction` simple provides tx data and requests that Pelagus serialize, sign, and broadcast the transaction. It is important to highlight that `eth_sendTransaction` is different than `eth_sendRawTransaction` in that it does not do any encoding or signing itself - `eth_sendRawTransaction` is explicitly unsupported.

Slight improvement to wallet provider injection logic