### PR TITLE
Bugfix: Display locked balance if it is greater than 0, including 1K+

### DIFF
--- a/background/services/internal-quai-provider/db.ts
+++ b/background/services/internal-quai-provider/db.ts
@@ -2,7 +2,7 @@ import Dexie from "dexie"
 
 import { PELAGUS_INTERNAL_ORIGIN } from "./constants"
 import { NetworkInterface } from "../../constants/networks/networkTypes"
-import { QuaiGoldenAgeTestnet } from "../../constants/networks/networks"
+import { QuaiGoldenAgeTestnet, QuaiOrchardTestnet } from "../../constants/networks/networks"
 
 type NetworkForOrigin = {
   origin: string
@@ -21,7 +21,7 @@ export class InternalQuaiProviderDatabase extends Dexie {
     this.on("populate", (tx) => {
       return tx.db
         .table("currentNetwork")
-        .add({ origin: PELAGUS_INTERNAL_ORIGIN, network: QuaiGoldenAgeTestnet })
+        .add({ origin: PELAGUS_INTERNAL_ORIGIN, network: QuaiOrchardTestnet })
     })
   }
 
@@ -36,6 +36,13 @@ export class InternalQuaiProviderDatabase extends Dexie {
     origin: string
   ): Promise<NetworkInterface | undefined> {
     const currentNetwork = await this.currentNetwork.get({ origin })
+    if(currentNetwork?.network.chainID == "9000") { // invalid stored chainID from golden age testnet
+      let internalNetwork = await this.currentNetwork.get({ origin: PELAGUS_INTERNAL_ORIGIN })
+      if(internalNetwork) {
+        await this.currentNetwork.put({ origin, network: internalNetwork.network })
+        return internalNetwork.network
+      }
+    }
     return currentNetwork?.network
   }
 

--- a/ui/components/Wallet/WalletAccountBalanceControl.tsx
+++ b/ui/components/Wallet/WalletAccountBalanceControl.tsx
@@ -293,7 +293,7 @@ export default function WalletAccountBalanceControl(
           isLoaded={!shouldIndicateLoadingHandle({ isActionsSkeleton: false })}
           customStyles="margin-top: 10px;"
         >
-          {formattedLockedBalance && Number(formattedLockedBalance) > 0 && (
+          {formattedLockedBalance && formattedLockedBalance != "0" && formattedLockedBalance != "0.00" && formattedLockedBalance != "0.000" && (
             <div className="locked_balance_card_wrap">
               <LockedBalanceCard
                 balance={formattedLockedBalance}


### PR DESCRIPTION
Also bugfix: reset stored chain ID for origins used in golden age to orchard chain ID