### PR TITLE
bugfix: propagate background error msg to UI instead of 'user rejected'

### DIFF
--- a/background/main.ts
+++ b/background/main.ts
@@ -885,11 +885,11 @@ export default class Main extends BaseService<never> {
     request,
   }: {
     request: QuaiTransactionRequest
-  }): Promise<boolean> {
+  }): Promise<{ success: boolean; errorMessage: string | null }> {
     try {
-      const transactionResponse =
+      const { transactionResponse, errorMessage } =
         await this.transactionService.signAndSendQuaiTransaction(request)
-      if (!transactionResponse) return false
+      if (!transactionResponse) return { success: false, errorMessage }
 
       await this.analyticsService.sendAnalyticsEvent(
         AnalyticsEvent.TRANSACTION_SIGNED,
@@ -899,12 +899,15 @@ export default class Main extends BaseService<never> {
       )
 
       this.store.dispatch(quaiTransactionResponse(transactionResponse))
-      return true
+      return { success: true, errorMessage: null }
     } catch (exception) {
       this.store.dispatch(
         clearTransactionState(TransactionConstructionStatus.Idle)
       )
-      return false
+      return {
+        success: false,
+        errorMessage: exception instanceof Error ? exception.message : "Unknown error",
+      }
     }
   }
 
@@ -1273,7 +1276,7 @@ export default class Main extends BaseService<never> {
   async connectInternalQuaiProviderService(): Promise<void> {
     this.internalQuaiProviderService.emitter.on(
       "transactionSendRequest",
-      async ({ payload, resolver, rejecter }) => {
+      async ({ payload, resolver, rejecter }: { payload: any, resolver: (result: any) => void, rejecter: (err?: any) => void }) => {
         this.store.dispatch(
           clearTransactionState(TransactionConstructionStatus.Pending)
         )
@@ -1302,7 +1305,8 @@ export default class Main extends BaseService<never> {
               resolver(response.signedTx)
               break
             default:
-              rejecter()
+              // Pass the error reason if available
+              rejecter(response.reason || undefined)
               break
           }
         }

--- a/background/redux-slices/assets.ts
+++ b/background/redux-slices/assets.ts
@@ -354,11 +354,11 @@ export const sendAsset = createBackgroundAsyncThunk(
         request.gasPrice = gasPrice
       }
 
-      const isSignedAndSent = await main.signAndSendQuaiTransaction({
+      const { success, errorMessage } = await main.signAndSendQuaiTransaction({
         request,
       })
 
-      return { success: isSignedAndSent }
+      return { success, errorMessage: errorMessage ?? undefined }
     } catch (error: any) {
       return {
         success: false,

--- a/background/services/internal-quai-provider/index.ts
+++ b/background/services/internal-quai-provider/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/return-await */
 import {
   TypedDataEncoder,
   hexlify,
@@ -172,14 +173,11 @@ export default class InternalQuaiProviderService extends BaseService<Events> {
         const { address } = await this.preferenceService.getSelectedAccount()
         return [address]
       }
-
       case "quai_getBalance":
       case "eth_getBalance":
-        return this.chainService.jsonRpcProvider.getBalance(
+        return await this.chainService.jsonRpcProvider.getBalance(
           params[0] as AddressLike
         )
-
-      // supported methods
       case "quai_signTypedData":
       case "quai_signTypedData_v1":
       case "quai_signTypedData_v3":
@@ -188,35 +186,32 @@ export default class InternalQuaiProviderService extends BaseService<Events> {
       case "eth_signTypedData_v1":
       case "eth_signTypedData_v3":
       case "eth_signTypedData_v4":
-        return this.signTypedData({
+        return await this.signTypedData({
           account: {
             address: params[0] as string,
             network: await this.getCurrentOrDefaultNetworkForOrigin(origin),
           },
           typedData: JSON.parse(params[1] as string),
         })
-
       case "quai_sign":
       case "eth_sign":
-        return this.signData(
+        return await this.signData(
           {
             input: params[1] as string,
             account: params[0] as string,
           },
           origin
         )
-
       case "personal_sign":
-        return this.signData(
+        return await this.signData(
           {
             input: params[0] as string,
             account: params[1] as string,
           },
           origin
         )
-
       case "qi_signAll":
-        return this.signData(
+        return await this.signData(
           {
             input: params[0] as string,
             account: params[1] as string,
@@ -224,151 +219,123 @@ export default class InternalQuaiProviderService extends BaseService<Events> {
           },
           origin
         )
-
       case "quai_blockNumber":
       case "eth_blockNumber":
         if (!params[0]) {
-          return this.chainService.jsonRpcProvider.getBlockNumber(
+          return await this.chainService.jsonRpcProvider.getBlockNumber(
             "0x00" as Shard
           )
-        } else {
-          return this.chainService.jsonRpcProvider.getBlockNumber(
-            params[0] as Shard
-          )
         }
-
+        return await this.chainService.jsonRpcProvider.getBlockNumber(
+          params[0] as Shard
+        )
       case "quai_getBlockByHash":
       case "quai_getBlockByNumber":
-        return this.chainService.jsonRpcProvider.getBlock(
+        return await this.chainService.jsonRpcProvider.getBlock(
           params[0] as Shard,
           params[1] as BlockTag,
           params[2] as boolean
         )
-
       case "eth_getBlockByHash":
       case "eth_getBlockByNumber":
-        return this.chainService.ethJsonRpcProvider.getBlock(
+        return await this.chainService.ethJsonRpcProvider.getBlock(
           params[0] as BlockTag,
           params[1] as boolean
         )
-
       case "quai_getTransactionReceipt":
-        return this.chainService.jsonRpcProvider.getTransactionReceipt(
+        return await this.chainService.jsonRpcProvider.getTransactionReceipt(
           params[0] as string
         )
       case "eth_getTransactionReceipt":
-        return this.chainService.ethJsonRpcProvider.getTransactionReceipt(
+        return await this.chainService.ethJsonRpcProvider.getTransactionReceipt(
           params[0] as string
         )
-
       case "quai_getTransactionByHash":
-        return this.chainService.jsonRpcProvider.getTransaction(
+        return await this.chainService.jsonRpcProvider.getTransaction(
           params[0] as string
         )
       case "eth_getTransactionByHash":
-        return this.chainService.ethJsonRpcProvider.getTransaction(
+        return await this.chainService.ethJsonRpcProvider.getTransaction(
           params[0] as string
         )
-
       case "quai_getTransactionCount":
       case "eth_getTransactionCount":
-        return this.chainService.jsonRpcProvider.getTransactionCount(
+        return await this.chainService.jsonRpcProvider.getTransactionCount(
           getAddress(params[0] as string),
           params[1] as quais.BlockTag
         )
-
       case "quai_estimateGas":
-        return this.chainService.jsonRpcProvider
+        return await this.chainService.jsonRpcProvider
           .estimateGas(params[0] as TransactionRequest)
           .then((estimatedGas) => estimatedGas.toString())
       case "eth_estimateGas":
-        return this.chainService.ethJsonRpcProvider
+        return await this.chainService.ethJsonRpcProvider
           .estimateGas(params[0] as EthTransactionRequest)
           .then((estimatedGas) => estimatedGas.toString())
-
       case "quai_createAccessList":
-        return this.chainService.jsonRpcProvider.createAccessList(
+        return await this.chainService.jsonRpcProvider.createAccessList(
           params[0] as TransactionRequest
         )
-
       case "quai_sendTransaction":
-      case "eth_sendTransaction":
+      case "eth_sendTransaction": {
         const request = params[0] as QuaiTransactionRequestWithAnnotation & {
           maxFeePerGas?: string
           maxPriorityFeePerGas?: string
         }
-        return this.sendTransaction(request, origin).then(
+        return await this.sendTransaction(request, origin).then(
           (transactionResponse) => transactionResponse.hash
         )
-
+      }
       case "quai_sendRawTransaction":
-        return this.chainService.jsonRpcProvider.broadcastTransaction(
+        return await this.chainService.jsonRpcProvider.broadcastTransaction(
           params[0] as Zone,
           params[1] as string
         )
-      case "eth_sendRawTransaction":
-        throw new Error(
-          "eth_sendRawTransaction is not supported. You must use quai_sendRawTransaction instead."
-        )
-
       case "quai_gasPrice":
       case "eth_gasPrice":
-        return this.chainService.jsonRpcProvider
+        return await this.chainService.jsonRpcProvider
           .getFeeData()
           .then((feeData) => feeData.gasPrice)
-
       case "quai_call":
       case "eth_call":
-        return this.chainService.jsonRpcProvider.call(
+        return await this.chainService.jsonRpcProvider.call(
           params[0] as QuaiTransactionRequest
         )
-
       case "quai_getLogs":
       case "quai_getFilterLogs":
-        return this.chainService.jsonRpcProvider.getLogs(
+        return await this.chainService.jsonRpcProvider.getLogs(
           params[0] as Filter | FilterByBlockHash
         )
       case "eth_getLogs":
       case "eth_getFilterLogs":
-        return this.chainService.ethJsonRpcProvider.getLogs(
+        return await this.chainService.ethJsonRpcProvider.getLogs(
           params[0] as EthFilter | EthFilterByBlockHash
         )
-
       case "quai_getCode":
       case "eth_getCode":
-        return this.chainService.jsonRpcProvider.getCode(
+        return await this.chainService.jsonRpcProvider.getCode(
           params[0] as AddressLike
         )
-
       case "quai_getStorageAt":
       case "eth_getStorageAt":
-        return this.chainService.jsonRpcProvider.getStorage(
+        return await this.chainService.jsonRpcProvider.getStorage(
           params[0] as AddressLike,
           params[1] as BigNumberish
         )
-
       case "quai_chainId":
       case "eth_chainId":
-        // TODO Decide on a better way to track whether a particular chain is
-        // allowed to have an RPC call made to it. Ideally this would be based
-        // on a user's idea of a dApp connection rather than a network-specific
-        // modality, requiring it to be constantly "switched"
         return toHexChainID(
           (await this.getCurrentOrDefaultNetworkForOrigin(origin)).chainID
         )
-
       case "quai_nodeLocation":
-        return this.chainService.jsonRpcProvider.getRunningLocations()
-
+        return await this.chainService.jsonRpcProvider.getRunningLocations()
       case "wallet_watchAsset": {
         const { type, options } = params[0]
           ? (params[0] as WatchAssetParameters)
-          : // some dapps send the object directly instead of an array
-            (params as unknown as WatchAssetParameters)
+          : (params as unknown as WatchAssetParameters)
         if (type !== "ERC20") {
           throw new EIP1193Error(EIP1193_ERROR_CODES.unsupportedMethod)
         }
-
         if (options.chainId) {
           const supportedNetwork = PELAGUS_NETWORKS.find(
             (network) => network.chainID === String(options.chainId)
@@ -382,17 +349,13 @@ export default class InternalQuaiProviderService extends BaseService<Events> {
           })
           return true
         }
-
-        // if chainID is not specified, we assume the current network - as per EIP-747
         const network = await this.getCurrentOrDefaultNetworkForOrigin(origin)
-
         this.emitter.emit("watchAssetRequest", {
           contractAddress: normalizeHexAddress(options.address),
           network,
         })
         return true
       }
-      // will just switch to a chain if we already support it - but not add a new one
       case "wallet_addEthereumChain": {
         const chainInfo = params[0] as ValidatedAddEthereumChainParameter
         const { chainId } = chainInfo
@@ -415,11 +378,8 @@ export default class InternalQuaiProviderService extends BaseService<Events> {
           this.switchToSupportedNetwork(origin, supportedNetwork)
           return null
         }
-
         throw new EIP1193Error(EIP1193_ERROR_CODES.chainDisconnected)
       }
-
-      // just "proxying" requests to quais
       case "quai_feeHistory":
       case "quai_getBlockTransactionCountByHash":
       case "quai_getBlockTransactionCountByNumber":
@@ -442,26 +402,19 @@ export default class InternalQuaiProviderService extends BaseService<Events> {
       case "net_version":
       case "web3_clientVersion":
       case "web3_sha3":
-        return this.transactionsService.send(method, params)
-
-      // unsupported methods
-
+        return await this.transactionsService.send(method, params)
       case "wallet_requestPermissions":
       case "wallet_getPermissions": {
         const { address } = await this.preferenceService.getSelectedAccount()
         const network = await this.getCurrentOrDefaultNetworkForOrigin(origin)
-
         const permission = await this.providerBridgeDb.checkPermission(
           origin,
           address,
           network.chainID
         )
-
         if (!permission) {
           return []
         }
-
-        // Format according to EIP-2255
         return [
           {
             invoker: origin,
@@ -575,7 +528,9 @@ export default class InternalQuaiProviderService extends BaseService<Events> {
       this.emitter.emit("transactionSendRequest", {
         payload,
         resolver: resolve,
-        rejecter: reject,
+        rejecter: (err?: any) => {
+          reject(err || new Error("Transaction was rejected (no error info)"));
+        },
       })
     })
   }

--- a/background/services/provider-bridge/index.ts
+++ b/background/services/provider-bridge/index.ts
@@ -657,8 +657,6 @@ export default class ProviderBridgeService extends BaseService<Events> {
         }
       }
     } catch (error: any) {
-      console.error(`Error processing request: ${error?.message || error}`)
-      logger.error(`Error processing request: ${error?.message || error}`)
       return handleRPCErrorResponse(error)
     }
   }

--- a/background/services/provider-bridge/utils.ts
+++ b/background/services/provider-bridge/utils.ts
@@ -61,7 +61,7 @@ export function handleRPCErrorResponse(error: unknown): unknown {
   let response
   if (typeof error === "object" && error !== null) {
     /**
-     * Get error per the RPC method’s specification
+     * Get error per the RPC method's specification
      */
     if ("eip1193Error" in error) {
       const { eip1193Error } = error as {
@@ -81,6 +81,17 @@ export function handleRPCErrorResponse(error: unknown): unknown {
       response = parsedRPCErrorResponse(
         (error as { error: { body: string } }).error
       )
+    } else if (error instanceof Error && error.message) {
+      response = {
+        code: 4001,
+        message: error.message,
+      }
+    }
+  } else if (typeof error === "string") {
+    // Handle string errors (e.g., propagated error messages)
+    response = {
+      code: 4001,
+      message: error,
     }
   }
   /**

--- a/background/services/signing/index.ts
+++ b/background/services/signing/index.ts
@@ -14,10 +14,9 @@ import { KeyringAccountSigner, PrivateKeyAccountSigner } from "../keyring/types"
 import { isSignerPrivateKeyType } from "../keyring/utils"
 import TransactionService from "../transactions"
 
-type SigningErrorReason = "userRejected" | "genericError"
 type ErrorResponse = {
   type: "error"
-  reason: SigningErrorReason
+  reason: string
 }
 
 export type SendTransactionResponse =
@@ -64,8 +63,10 @@ type AddressHandler = {
   signer: SignerType
 }
 
-function getSigningErrorReason(err: unknown): SigningErrorReason {
-  return "genericError"
+function getSigningErrorReason(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Unknown signing error";
 }
 
 /**
@@ -146,14 +147,18 @@ export default class SigningService extends BaseService<Events> {
     accountSigner: AccountSigner
   ): Promise<QuaiTransactionResponse> {
     try {
-      let transactionResponse: QuaiTransactionResponse | null
+      let txResponse: QuaiTransactionResponse | null
       switch (accountSigner.type) {
         case "private-key":
         case "keyring": {
-          transactionResponse =
+          const { transactionResponse, errorMessage } =
             await this.transactionService.signAndSendQuaiTransaction(
               transactionRequest
             )
+          txResponse = transactionResponse
+          if (errorMessage) {
+            throw new Error(errorMessage)
+          }
           break
         }
         case "read-only":
@@ -162,16 +167,16 @@ export default class SigningService extends BaseService<Events> {
           return assertUnreachable(accountSigner)
       }
 
-      if (!transactionResponse) {
+      if (!txResponse) {
         throw new Error("Transaction response is null.")
       }
 
       await this.emitter.emit("sendTransactionResponse", {
         type: "success-tx",
-        signedTx: transactionResponse,
+        signedTx: txResponse,
       })
 
-      return transactionResponse
+      return txResponse
     } catch (err) {
       await this.emitter.emit("sendTransactionResponse", {
         type: "error",

--- a/background/services/transactions/index.ts
+++ b/background/services/transactions/index.ts
@@ -107,7 +107,10 @@ export default class TransactionService extends BaseService<TransactionServiceEv
    */
   public async signAndSendQuaiTransaction(
     request: QuaiTransactionRequest
-  ): Promise<QuaiTransactionResponse | null> {
+  ): Promise<{
+    transactionResponse: QuaiTransactionResponse | null
+    errorMessage: string | null
+  }> {
     try {
       const { jsonRpcProvider } = this.chainService
       let transactionResponse: QuaiTransactionResponse
@@ -126,13 +129,16 @@ export default class TransactionService extends BaseService<TransactionServiceEv
         )) as QuaiTransactionResponse
       }
       await this.processQuaiTransactionResponse(transactionResponse)
-      return transactionResponse
+      return { transactionResponse, errorMessage: null }
     } catch (error: any) {
       logger.error(
         `Failed to sign and send Quai transaction: ${error?.message || error}`
       )
       this.emitter.emit("transactionSendFailure")
-      return null
+      return {
+        transactionResponse: null,
+        errorMessage: error?.message || error,
+      }
     }
   }
 

--- a/ui/pages/Send.tsx
+++ b/ui/pages/Send.tsx
@@ -84,6 +84,8 @@ export default function Send(): ReactElement {
 
   const [advancedVisible, setAdvancedVisible] = useState(false)
 
+  const [transactionErrorMessage, setTransactionErrorMessage] = useState<string | undefined>(undefined);
+
   const handleAssetSelect = (asset: FungibleAsset) => {
     setSelectedAsset(asset)
     setAssetType("token")
@@ -202,10 +204,11 @@ export default function Send(): ReactElement {
         transferDetails.nonce = nonce
       }
 
-      const { success } = (await dispatch(
+      const { success, errorMessage } = (await dispatch(
         sendAsset(transferDetails)
       )) as AsyncThunkFulfillmentType<typeof sendAsset>
       setIsTransactionError(!success)
+      setTransactionErrorMessage(errorMessage)
     } catch (e) {
       setIsTransactionError(true)
     } finally {
@@ -257,7 +260,7 @@ export default function Send(): ReactElement {
     const confirmationModalProps = isTransactionError
       ? {
           headerTitle: confirmationLocales("send.errorHeadline"),
-          subtitle: confirmationLocales("send.errorSubtitle"),
+          subtitle: transactionErrorMessage || confirmationLocales("send.errorSubtitle"),
           title: `${confirmationLocales("send.errorTitle")}!`,
           icon: {
             src: "icons/s/notif-wrong.svg",


### PR DESCRIPTION
This fix propagates the background error to the ui, instead of defaulting to "transaction rejected by user" default message. 
Example of error rendered in poop.fun:

![Screenshot 2025-05-16 at 12 23 25 PM](https://github.com/user-attachments/assets/19f349f6-dd0a-46a1-93cc-907ca85a9fb9)
